### PR TITLE
Add Client#close()

### DIFF
--- a/spec/client/Client.spec.ts
+++ b/spec/client/Client.spec.ts
@@ -332,4 +332,16 @@ describe('Client', function (): void {
 			})
 		})
 	}) // #toJSON()
+
+	describe('#close()', function (): void {
+		it('closes all watches', async function (): Promise<void> {
+			jest.spyOn(client.watch, 'close')
+			jest.spyOn(client.ops.watch, 'close')
+
+			await client.close()
+
+			expect(client.watch.close).toBeCalled()
+			expect(client.ops.watch.close).toBeCalled()
+		})
+	}) // #close()
 })

--- a/spec/client/watches/Watch.spec.ts
+++ b/spec/client/watches/Watch.spec.ts
@@ -103,6 +103,28 @@ describe('Watch', function (): void {
 		})
 	}) // .open()
 
+	describe('.close()', function (): void {
+		let openedWatch: Watch
+
+		beforeEach(async function (): Promise<void> {
+			asMock(subject.get).mockReturnValue(fooDict)
+
+			openedWatch = await Watch.open({
+				subject,
+				ids: 'foo',
+				display: 'display',
+			})
+		})
+
+		it('closes all watches for the subject', async function (): Promise<void> {
+			expect(openedWatch.isClosed()).toBe(false)
+
+			await Watch.close(subject)
+
+			expect(openedWatch.isClosed()).toBe(true)
+		})
+	}) // .close()
+
 	describe('#add()', function (): void {
 		it('rejects if the watch is already closed', async function (): Promise<void> {
 			await watch.close()

--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -371,4 +371,14 @@ export class Client implements ClientServiceConfig {
 
 		return fetchVal<T>(resource, fetchValOptions, this.fetch)
 	}
+
+	/**
+	 * Closes the client.
+	 *
+	 * Warning: this will close any watches associated with this client. Any
+	 * watches may throw an error if they are used after being closed.
+	 */
+	public async close(): Promise<void> {
+		await Promise.all([this.watch.close(), this.ops.watch.close()])
+	}
 }

--- a/src/client/watches/Watch.ts
+++ b/src/client/watches/Watch.ts
@@ -221,6 +221,23 @@ export class Watch {
 	}
 
 	/**
+	 * Close all watches for the given subject.
+	 *
+	 * Please note, this method doesn't normally need to be called
+	 * and is designed to be used internally. If you want
+	 * to close a watch then please just call `Watch.#close()` instead.
+	 *
+	 * @param subject The subject to close watches for.
+	 */
+	public static async close(subject: Subject): Promise<void> {
+		await Promise.all(
+			[...watches]
+				.filter((watch) => watch.#subject === subject)
+				.map((watch) => watch.close())
+		)
+	}
+
+	/**
 	 * Add records to watch.
 	 *
 	 * ```typescript

--- a/src/client/watches/WatchService.ts
+++ b/src/client/watches/WatchService.ts
@@ -59,4 +59,11 @@ export class WatchService {
 			grid,
 		})
 	}
+
+	/**
+	 * Closes any open watches for this watch service.
+	 */
+	public async close(): Promise<void> {
+		await Watch.close(this.#subject)
+	}
 }


### PR DESCRIPTION
Added Client#close() method.

Techincally this speaking this isn't needed if all outstanding associated Watches are closed. I think it's a nice to have anyway.

Please note, if anything attempts to use a Watch beyond it being used, an error will be thrown.