### PR TITLE
Fixed CSRF recovery and added Configurable CSRF Attest Headers

### DIFF
--- a/spec/client/finCsrfFetch.spec.ts
+++ b/spec/client/finCsrfFetch.spec.ts
@@ -10,6 +10,7 @@ import {
 	getFinCsrfToken,
 	CsrfError,
 	isCsrfError,
+	CsrfRequestInit,
 } from '../../src/client/finCsrfFetch'
 import {
 	FIN_AUTH_PATH,
@@ -24,6 +25,9 @@ describe('finCsrfFetch', function (): void {
 	const ABS_URL = 'https://www.foobar.com'
 	const ABS_READ = `${ABS_URL}/read`
 	const ABS_FIN_AUTH_PATH = `${ABS_URL}${FIN_AUTH_PATH}`
+
+	const ABS_ALT_AUTH_PATH = `${ABS_URL}/altAuthPath`
+	const ALT_AUTH_HEADER = 'alt-attest-key'
 
 	let respGrid: HGrid
 	let zinc: string
@@ -55,6 +59,12 @@ describe('finCsrfFetch', function (): void {
 
 		authResponse.headers[FIN_AUTH_KEY] = 'aKey'
 
+		const altAuthResponse: { headers: { [prop: string]: string } } = {
+			headers: {
+				[ALT_AUTH_HEADER]: 'altKey',
+			},
+		}
+
 		zinc = respGrid.toZinc()
 		fetchMock
 			.reset()
@@ -62,6 +72,7 @@ describe('finCsrfFetch', function (): void {
 			.get(READ, zinc)
 			.post(ABS_FIN_AUTH_PATH, (): unknown => authResponse)
 			.get(ABS_READ, zinc)
+			.post(ABS_ALT_AUTH_PATH, (): unknown => altAuthResponse)
 	}
 
 	beforeEach(function (): void {
@@ -93,6 +104,25 @@ describe('finCsrfFetch', function (): void {
 		it('makes one call for the CSRF token', async function (): Promise<void> {
 			await finCsrfFetch(READ)
 			expect(fetchMock.calls(FIN_AUTH_PATH).length).toBe(1)
+		})
+
+		it('fetches a CSRF token via alt configuration', async function (): Promise<void> {
+			await finCsrfFetch(READ, {
+				attestHeaderName: ALT_AUTH_HEADER,
+				attestRequestUri: ABS_ALT_AUTH_PATH,
+				attestResponseHeaderName: ALT_AUTH_HEADER,
+			} as CsrfRequestInit)
+			expect(fetchMock.called(ABS_ALT_AUTH_PATH)).toBe(true)
+		})
+
+		it('makes one call for the CSRF token via alt configuration', async function (): Promise<void> {
+			await finCsrfFetch(READ, {
+				attestHeaderName: ALT_AUTH_HEADER,
+				attestRequestUri: ABS_ALT_AUTH_PATH,
+				attestResponseHeaderName: ALT_AUTH_HEADER,
+			} as CsrfRequestInit)
+
+			expect(fetchMock.calls(ABS_ALT_AUTH_PATH).length).toBe(1)
 		})
 
 		it('throws an error if the CSRF token cannot be retreived', async function (): Promise<void> {

--- a/src/client/finAuthFetch.ts
+++ b/src/client/finAuthFetch.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2022, J2 Innovations. All Rights Reserved
  */
 
-import { finCsrfFetch, isCsrfError } from './finCsrfFetch'
+import { CsrfRequestInit, finCsrfFetch, isCsrfError } from './finCsrfFetch'
 import { FetchMethod } from './fetchVal'
 
 /**
@@ -162,7 +162,7 @@ async function authenticateResponse(
 /**
  * Request Init with Authenticator
  */
-export interface RequestInitAuth extends RequestInit {
+export interface RequestInitAuth extends CsrfRequestInit {
 	/**
 	 * Request Authenticator
 	 */


### PR DESCRIPTION
Configurable CSRF Headers:
 1. Configurable token request path
 2. Configurable token header key
 3. Configurable token request result header key

Changed "addAttestKey" check to "hasAttestKey" to test if the request currently has an attest key.
This enables recovery in the case the attest key was passed in the headers but was invalid.