### PR TITLE
Enhancement/attest key request headers

### DIFF
--- a/spec/client/finCsrfFetch.spec.ts
+++ b/spec/client/finCsrfFetch.spec.ts
@@ -68,11 +68,21 @@ describe('finCsrfFetch', function (): void {
 		zinc = respGrid.toZinc()
 		fetchMock
 			.reset()
-			.post(FIN_AUTH_PATH, (): unknown => authResponse)
+			.post(FIN_AUTH_PATH, (request, options): unknown => {
+				if (options.headers && SKYARC_ATTEST_KEY in options.headers) {
+					throw new Error('Attest key exists in attest request')
+				}
+				return authResponse
+			})
 			.get(READ, zinc)
 			.post(ABS_FIN_AUTH_PATH, (): unknown => authResponse)
 			.get(ABS_READ, zinc)
-			.post(ABS_ALT_AUTH_PATH, (): unknown => altAuthResponse)
+			.post(ABS_ALT_AUTH_PATH, (request, options): unknown => {
+				if (options.headers && ALT_AUTH_HEADER in options.headers) {
+					throw new Error('Attest key exists in attest request')
+				}
+				return altAuthResponse
+			})
 	}
 
 	beforeEach(function (): void {

--- a/spec/util/http.spec.ts
+++ b/spec/util/http.spec.ts
@@ -14,6 +14,7 @@ import {
 	getHostServiceUrl,
 	encodeQuery,
 	addStartSlashRemoveEndSlash,
+	removeHeader,
 } from '../../src/util/http'
 import { Headers as NodeHeaders } from 'node-fetch'
 
@@ -165,6 +166,34 @@ describe('http', function (): void {
 			expect(obj.headers?.foo).toBe('val')
 		})
 	}) // addHeader()
+
+	describe('removeHeader()', function (): void {
+		it('sets a value in an existing headers object then remove', function (): void {
+			const headers = makeHeaders({})
+			addHeader({ headers }, 'foo', 'val')
+			expect(headers.get('foo')).toBe('val')
+			removeHeader(headers, 'foo')
+			expect(headers.get('foo')).toBeNull()
+		})
+
+		it('adds to an existing headers object literal with a new value then remove', function (): void {
+			const headers: HeadersObj = {}
+			const obj = { headers }
+			addHeader(obj, 'foo', 'val')
+			expect(obj.headers).toBe(headers)
+			expect(obj.headers.foo).toBe('val')
+			removeHeader(obj.headers, 'foo')
+			expect(obj.headers.foo).toBeUndefined()
+		})
+
+		it('creates an new headers object literal with the new value then remove', function (): void {
+			const obj: { headers?: { [prop: string]: string } } = {}
+			addHeader(obj, 'foo', 'val')
+			expect(obj.headers?.foo).toBe('val')
+			removeHeader(obj.headers, 'foo')
+			expect(obj.headers?.foo).toBeUndefined()
+		})
+	}) // removeHeader()
 
 	describe('#getOpUrl()', function (): void {
 		it('returns a URL', function (): void {

--- a/src/client/finCsrfFetch.ts
+++ b/src/client/finCsrfFetch.ts
@@ -171,6 +171,21 @@ export async function finCsrfFetch(
 		: SKYARC_ATTEST_KEY
 
 	async function addAttestKeyHeader(): Promise<boolean> {
+		if (hsOptions.headers) {
+			if (isHeaders(hsOptions.headers)) {
+				hsOptions.headers.delete(attestHeaderName)
+			} else if (Array.isArray(hsOptions.headers)) {
+				const index = hsOptions.headers.findIndex(
+					(item) => item[0] === attestHeaderName
+				)
+
+				if (index > -1) {
+					hsOptions.headers.splice(index, 1)
+				}
+			} else {
+				delete hsOptions.headers[attestHeaderName]
+			}
+		}
 		const attestKey = await getAttestKey(String(resource), hsOptions)
 
 		// Only add the attest key if we have one. Some haystack servers may not use this key.
@@ -216,4 +231,9 @@ export function isCsrfRequestInit(
 	value?: RequestInit
 ): value is CsrfRequestInit {
 	return !!value && 'attestHeaderName' in value
+}
+
+const HEADERS_PROPS = ['set', 'get', 'delete', 'has']
+function isHeaders(value?: HeadersInit): value is Headers {
+	return !!value && HEADERS_PROPS.every((item) => item in value)
 }

--- a/src/client/finCsrfFetch.ts
+++ b/src/client/finCsrfFetch.ts
@@ -12,6 +12,7 @@ import {
 	FIN_AUTH_PATH,
 	FIN_AUTH_KEY,
 	SKYARC_ATTEST_KEY,
+	removeHeader,
 } from '../util/http'
 
 /**
@@ -171,21 +172,8 @@ export async function finCsrfFetch(
 		: SKYARC_ATTEST_KEY
 
 	async function addAttestKeyHeader(): Promise<boolean> {
-		if (hsOptions.headers) {
-			if (isHeaders(hsOptions.headers)) {
-				hsOptions.headers.delete(attestHeaderName)
-			} else if (Array.isArray(hsOptions.headers)) {
-				const index = hsOptions.headers.findIndex(
-					(item) => item[0] === attestHeaderName
-				)
+		removeHeader(hsOptions.headers, attestHeaderName)
 
-				if (index > -1) {
-					hsOptions.headers.splice(index, 1)
-				}
-			} else {
-				delete hsOptions.headers[attestHeaderName]
-			}
-		}
 		const attestKey = await getAttestKey(String(resource), hsOptions)
 
 		// Only add the attest key if we have one. Some haystack servers may not use this key.
@@ -231,9 +219,4 @@ export function isCsrfRequestInit(
 	value?: RequestInit
 ): value is CsrfRequestInit {
 	return !!value && 'attestHeaderName' in value
-}
-
-const HEADERS_PROPS = ['set', 'get', 'delete', 'has']
-function isHeaders(value?: HeadersInit): value is Headers {
-	return !!value && HEADERS_PROPS.every((item) => item in value)
 }

--- a/src/util/http.ts
+++ b/src/util/http.ts
@@ -307,6 +307,49 @@ export function addHeader(
 }
 
 /**
+ * Remove the header value from the headers object by name.
+ *
+ * @param headers The headers object.
+ * @param headerName The headers name to look for.
+ * @returns The headers object
+ */
+export function removeHeader(
+	headers: HeadersInit | undefined,
+	headerName: string
+): HeadersInit | undefined {
+	if (!headers) {
+		return headers
+	}
+
+	// Handle Headers object.
+	if (isHeaders(headers)) {
+		headers.delete(headerName)
+		return headers
+	}
+
+	// Handle Array Case
+	if (Array.isArray(headers)) {
+		const index = headers.findIndex((item) => item[0] === headerName)
+
+		if (index > -1) {
+			headers.splice(index, 1)
+			return headers
+		}
+	} else {
+		// Handle object literal.
+		const header = headerName.toLowerCase()
+		for (const name in headers) {
+			if (name.toLowerCase() === header) {
+				delete headers[name]
+				return headers
+			}
+		}
+	}
+
+	return headers
+}
+
+/**
  * Adds a starting slash and removes any ending slash.
  *
  * @param path The path to update.


### PR DESCRIPTION
Removed invalid attest key header before requesting a new one. It was observed that when the old attest key was in the header while requesting a new one, this caused a remote system to terminate the connection. Instead of receiving a new CSRF token and replaying the request, the end result was a 400 error 'invalid attest key'