### PR TITLE
Allow duplicates to be added via batching of watch ids

### DIFF
--- a/spec/client/watches/BatchSubject.spec.ts
+++ b/spec/client/watches/BatchSubject.spec.ts
@@ -35,6 +35,7 @@ describe('BatchSubject', function (): void {
 			await Promise.all([
 				batch.add(['a']),
 				batch.add(['b']),
+				batch.add(['a']),
 				batch.remove(['c']),
 				batch.remove(['d']),
 				batch.remove(['e']),
@@ -43,7 +44,7 @@ describe('BatchSubject', function (): void {
 				batch.add(['h']),
 			])
 
-			expect(ops.join(',')).toBe('add:a,b,remove:c,d,e,f,add:g,h')
+			expect(ops.join(',')).toBe('add:a,b,a,remove:c,d,e,f,add:g,h')
 		})
 
 		it('invokes all operations in order', async function (): Promise<void> {

--- a/src/client/watches/BatchSubject.ts
+++ b/src/client/watches/BatchSubject.ts
@@ -128,9 +128,7 @@ export class BatchSubject implements Subject {
 		// If the last op was the same as this then coalesce the request.
 		if (lastOp?.op === op) {
 			for (const id of ids) {
-				if (!lastOp.ids.includes(id)) {
-					lastOp.ids.push(id)
-				}
+				lastOp.ids.push(id)
 			}
 
 			// Chain the new promise onto the existing one so it executes in sequence.


### PR DESCRIPTION
The watch framework batches add and remove requests together. However I found that adding twice followed by a remove screws up the reference counting for keeping watches open.

This fix addresses that issue by allowing...

- Duplicate adds to pass through `BatchSubject`.
- Enable duplicate ids to be handled in `ApiSubject`. 