### PR TITLE
STK-1409: add watch service update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-prettier": "^4.2.1",
 				"fetch-mock": "^9.10.7",
-				"haystack-core": "^2.0.44",
+				"haystack-core": "^2.0.45",
 				"html-loader": "^4.1.0",
 				"html-webpack-plugin": "^5.5.0",
 				"jest": "^29.0.1",
@@ -51,7 +51,7 @@
 				"write-file-webpack-plugin": "^4.5.1"
 			},
 			"peerDependencies": {
-				"haystack-core": "^2.0.43"
+				"haystack-core": "^2.0.44"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -7172,9 +7172,9 @@
 			}
 		},
 		"node_modules/haystack-core": {
-			"version": "2.0.44",
-			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.44.tgz",
-			"integrity": "sha512-VyW7VOANZpUoFYl53Fp/uOHVPH3rIfF9OqVWZowJehsa7nXiRvig2MalpxeKqzS978HD1ZGR8Ln2uRiDudXioA==",
+			"version": "2.0.45",
+			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.45.tgz",
+			"integrity": "sha512-sbHktwICEbUG1OENwpvKqhSF2AULYZQ5m0ng/qsZW74aFmTcBK6SEoPNMx2jY5p+XrQRCf8A8U/zCFl+80rebg==",
 			"dev": true
 		},
 		"node_modules/he": {
@@ -20113,9 +20113,9 @@
 			"dev": true
 		},
 		"haystack-core": {
-			"version": "2.0.44",
-			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.44.tgz",
-			"integrity": "sha512-VyW7VOANZpUoFYl53Fp/uOHVPH3rIfF9OqVWZowJehsa7nXiRvig2MalpxeKqzS978HD1ZGR8Ln2uRiDudXioA==",
+			"version": "2.0.45",
+			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.45.tgz",
+			"integrity": "sha512-sbHktwICEbUG1OENwpvKqhSF2AULYZQ5m0ng/qsZW74aFmTcBK6SEoPNMx2jY5p+XrQRCf8A8U/zCFl+80rebg==",
 			"dev": true
 		},
 		"he": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "haystack-nclient",
-			"version": "3.0.30",
+			"version": "3.0.31",
 			"license": "BSD-3-Clause",
 			"devDependencies": {
 				"@babel/core": "^7.18.13",
@@ -26,7 +26,7 @@
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-prettier": "^4.2.1",
 				"fetch-mock": "^9.10.7",
-				"haystack-core": "^2.0.43",
+				"haystack-core": "^2.0.44",
 				"html-loader": "^4.1.0",
 				"html-webpack-plugin": "^5.5.0",
 				"jest": "^29.0.1",
@@ -7172,9 +7172,9 @@
 			}
 		},
 		"node_modules/haystack-core": {
-			"version": "2.0.43",
-			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.43.tgz",
-			"integrity": "sha512-AuCcodVEnlqX788Vhe7qgh04MToZtXtn9gsEEjJ8CWlLJ/htDRGdU7vM+WW4f70RDsg2LcDD6dxarNL3NCMHQA==",
+			"version": "2.0.44",
+			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.44.tgz",
+			"integrity": "sha512-VyW7VOANZpUoFYl53Fp/uOHVPH3rIfF9OqVWZowJehsa7nXiRvig2MalpxeKqzS978HD1ZGR8Ln2uRiDudXioA==",
 			"dev": true
 		},
 		"node_modules/he": {
@@ -17784,7 +17784,8 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
 			"integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.5.0",
@@ -17799,7 +17800,8 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
 			"integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -17839,7 +17841,8 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ajv": {
 			"version": "6.12.6",
@@ -17886,7 +17889,8 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"ansi-escapes": {
 			"version": "4.3.2",
@@ -19320,7 +19324,8 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
 			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"eslint-plugin-prettier": {
 			"version": "4.2.1",
@@ -20108,9 +20113,9 @@
 			"dev": true
 		},
 		"haystack-core": {
-			"version": "2.0.43",
-			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.43.tgz",
-			"integrity": "sha512-AuCcodVEnlqX788Vhe7qgh04MToZtXtn9gsEEjJ8CWlLJ/htDRGdU7vM+WW4f70RDsg2LcDD6dxarNL3NCMHQA==",
+			"version": "2.0.44",
+			"resolved": "https://registry.npmjs.org/haystack-core/-/haystack-core-2.0.44.tgz",
+			"integrity": "sha512-VyW7VOANZpUoFYl53Fp/uOHVPH3rIfF9OqVWZowJehsa7nXiRvig2MalpxeKqzS978HD1ZGR8Ln2uRiDudXioA==",
 			"dev": true
 		},
 		"he": {
@@ -21690,7 +21695,8 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"jest-regex-util": {
 			"version": "29.0.0",
@@ -25358,7 +25364,8 @@
 					"version": "1.8.0",
 					"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 					"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},
@@ -25539,7 +25546,8 @@
 					"version": "8.5.0",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
 					"integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"fetch-mock": "^9.10.7",
-		"haystack-core": "^2.0.44",
+		"haystack-core": "^2.0.45",
 		"html-loader": "^4.1.0",
 		"html-webpack-plugin": "^5.5.0",
 		"jest": "^29.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"fetch-mock": "^9.10.7",
-		"haystack-core": "^2.0.43",
+		"haystack-core": "^2.0.44",
 		"html-loader": "^4.1.0",
 		"html-webpack-plugin": "^5.5.0",
 		"jest": "^29.0.1",
@@ -73,6 +73,6 @@
 		"write-file-webpack-plugin": "^4.5.1"
 	},
 	"peerDependencies": {
-		"haystack-core": "^2.0.43"
+		"haystack-core": "^2.0.44"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
 		"write-file-webpack-plugin": "^4.5.1"
 	},
 	"peerDependencies": {
-		"haystack-core": "^2.0.44"
+		"haystack-core": "^2.0.45"
 	}
 }

--- a/spec/client/watches/ApiSubject.spec.ts
+++ b/spec/client/watches/ApiSubject.spec.ts
@@ -377,7 +377,7 @@ describe('ApiSubject', function (): void {
 			expect(cb).not.toHaveBeenCalled()
 		})
 
-		it('invokes a callback is the new data is newer than the current', async () => {
+		it('invokes a callback if the new data is newer than the current', async () => {
 			const currentMod = HDateTime.make('2021-01-31T19:38:11.019Z')
 			const newMod = HDateTime.make('2022-01-31T19:38:11.019Z')
 

--- a/spec/client/watches/ApiSubject.spec.ts
+++ b/spec/client/watches/ApiSubject.spec.ts
@@ -360,7 +360,7 @@ describe('ApiSubject', function (): void {
 			expect(cb).toHaveBeenCalledWith(event)
 		})
 
-		it('does not invoke a callback is the new data is older than the current', async () => {
+		it('does not invoke a callback if the new data is older than the current', async () => {
 			firstDict.set('mod', HDateTime.make('2022-01-31T19:38:11.019Z'))
 
 			const changed = [

--- a/spec/client/watches/ApiSubject.spec.ts
+++ b/spec/client/watches/ApiSubject.spec.ts
@@ -17,6 +17,7 @@ import {
 	HStr,
 	HNamespace,
 	HDateTime,
+	HMarker,
 } from 'haystack-core'
 import {
 	WatchEventType,
@@ -723,4 +724,75 @@ describe('ApiSubject', function (): void {
 			)
 		})
 	}) // #pollRate
+
+	describe('#canUpdate()', () => {
+		it('returns false for two dicts that are the same with no timestamp', () => {
+			expect(
+				ApiSubject.canUpdate(
+					new HDict({ test: HMarker.make() }),
+					new HDict({ test: HMarker.make() })
+				)
+			).toBe(false)
+		})
+
+		it('returns false when the newer dict has an older timestamp', () => {
+			expect(
+				ApiSubject.canUpdate(
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					}),
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-01-02T11:57:29.055Z'),
+					})
+				)
+			).toBe(false)
+		})
+
+		it('returns false when the newer dict has the same timestamp and the dicts are equal', () => {
+			expect(
+				ApiSubject.canUpdate(
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					}),
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					})
+				)
+			).toBe(false)
+		})
+
+		it('returns true when the newer dict has the same timestamp and the dicts are not equal', () => {
+			expect(
+				ApiSubject.canUpdate(
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					}),
+					new HDict({
+						foobar: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					})
+				)
+			).toBe(true)
+		})
+
+		it('returns true when the newer dict has an newer timestamp', () => {
+			expect(
+				ApiSubject.canUpdate(
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-02-02T11:57:29.055Z'),
+					}),
+					new HDict({
+						test: HMarker.make(),
+						mod: HDateTime.make('2023-03-02T11:57:29.055Z'),
+					})
+				)
+			).toBe(true)
+		})
+	}) // #canUpdate()
 })

--- a/spec/client/watches/BatchSubject.spec.ts
+++ b/spec/client/watches/BatchSubject.spec.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2021, J2 Innovations. All Rights Reserved
  */
 
+import { HGrid } from 'haystack-core'
 import { BatchSubject } from '../../../src/client/watches/BatchSubject'
 import { Subject } from '../../../src/client/watches/Subject'
 
@@ -20,6 +21,7 @@ describe('BatchSubject', function (): void {
 			remove: jest.fn().mockImplementation(async (ids: string[]) => {
 				ops.push('remove:' + ids.join(','))
 			}),
+			update: jest.fn(),
 		} as unknown as Subject
 
 		batch = new BatchSubject(subject)
@@ -107,4 +109,12 @@ describe('BatchSubject', function (): void {
 			expect(order).toBe('abcdefghi')
 		})
 	}) // #remove()
+
+	describe('#update()', () => {
+		it('calls inner subject update', async () => {
+			const grid = new HGrid()
+			await batch.update(grid)
+			expect(subject.update).toHaveBeenCalledWith(grid)
+		})
+	}) // #update()
 })

--- a/spec/client/watches/Watch.spec.ts
+++ b/spec/client/watches/Watch.spec.ts
@@ -30,6 +30,7 @@ describe('Watch', function (): void {
 			on: jest.fn(),
 			off: jest.fn(),
 			get: jest.fn(),
+			update: jest.fn(),
 			inspect: jest.fn(),
 		}
 

--- a/src/client/watches/ApiSubject.ts
+++ b/src/client/watches/ApiSubject.ts
@@ -469,7 +469,7 @@ export class ApiSubject implements Subject {
 	 * @param newDict The new dict.
 	 * @returns True if an update can be triggered.
 	 */
-	private static canUpdate(curDict: HDict, newDict: HDict): boolean {
+	public static canUpdate(curDict: HDict, newDict: HDict): boolean {
 		const curMod = curDict.get<HDateTime>('mod')
 		const newMod = newDict.get<HDateTime>('mod')
 

--- a/src/client/watches/BatchSubject.ts
+++ b/src/client/watches/BatchSubject.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
-import { HRef, HDict } from 'haystack-core'
+import { HRef, HDict, HGrid } from 'haystack-core'
 import { Subject, SubjectChangedEventHandler } from './Subject'
 import { makeDeferred, Deferred } from '../../util/promise'
 
@@ -212,6 +212,15 @@ export class BatchSubject implements Subject {
 	 */
 	public get(id: string | HRef): HDict | undefined {
 		return this.#subject.get(id)
+	}
+
+	/**
+	 * Used to manually trigger a watch update.
+	 *
+	 * @param grid A grid of dicts to update.
+	 */
+	public async update(grid: HGrid): Promise<void> {
+		return this.#subject.update(grid)
 	}
 
 	/**

--- a/src/client/watches/Subject.ts
+++ b/src/client/watches/Subject.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
-import { HRef, HDict } from 'haystack-core'
+import { HRef, HDict, HGrid } from 'haystack-core'
 import { WatchChangedEvent } from './WatchEvent'
 
 /**
@@ -68,6 +68,13 @@ export interface Subject {
 	 * @returns The dict or undefined if it can't be found.
 	 */
 	get(id: string | HRef): HDict | undefined
+
+	/**
+	 * Used to manually trigger a watch update.
+	 *
+	 * @param grid A grid of dicts to update.
+	 */
+	update(grid: HGrid): Promise<void>
 
 	/**
 	 * Inspect the subject.

--- a/src/client/watches/WatchService.ts
+++ b/src/client/watches/WatchService.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
-import { HGrid } from 'haystack-core'
-import { Ids } from '../../util/hval'
+import { HaysonDict, HDict, HGrid, HList } from 'haystack-core'
+import { dictsToGrid, Ids } from '../../util/hval'
 import { ClientServiceConfig } from '../ClientServiceConfig'
 import { DEFAULT_POLL_RATE_SECS, Watch } from './Watch'
 import { ApiSubject } from './ApiSubject'
@@ -65,5 +65,27 @@ export class WatchService {
 	 */
 	public async close(): Promise<void> {
 		await Watch.close(this.#subject)
+	}
+
+	/**
+	 * Triggers a manual update of the watches.
+	 *
+	 * This is used to manually update dicts outside of a poll.
+	 * Providing the dicts are newer and they're being watched, any
+	 * listeners will receive the update as if they were updated from
+	 * the server via a watch poll request.
+	 *
+	 * @param dicts The dicts to update.
+	 */
+	public async update(
+		dicts:
+			| HDict
+			| HaysonDict
+			| HDict[]
+			| HaysonDict[]
+			| HGrid
+			| HList<HDict>
+	): Promise<void> {
+		return this.#subject.update(dictsToGrid(dicts))
 	}
 }


### PR DESCRIPTION
This enables a developer to manually trigger a watch update without a poll request.

It's useful if you've just made a server side call and you want to also update any other changes in the UI without triggering a poll.

I know WebSockets would obviously solve this problem better. Stil this is useful for now.