### PR TITLE
Scheduler Service - Implemented updated REST API and Types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "haystack-nclient",
-	"version": "3.0.34",
+	"version": "3.0.35",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "haystack-nclient",
-			"version": "3.0.34",
+			"version": "3.0.35",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"haystack-core": "^2.0.46"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"license": "BSD-3-Clause",
 	"author": "Gareth Johnson",
 	"homepage": "https://github.com/j2inn/haystack-nclient",
-	"version": "3.0.34",
+	"version": "3.0.35",
 	"module": "dist/index.es.js",
 	"main": "dist/index.js",
 	"scripts": {

--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -205,7 +205,7 @@ describe('ScheduleService', () => {
 			d1.remove('id')
 			d1.remove('schedule')
 
-			const d2 = HDict.make(d1)
+			const d2 = HDict.make(d1) as Schedule
 			const payload = HGrid.make([d1, d2])
 
 			await service.createSchedules(payload)
@@ -253,9 +253,9 @@ describe('ScheduleService', () => {
 		})
 
 		it('updates a schedule specified by an id', async () => {
-			const sch = mockSchedule()
+			const schedule = mockSchedule()
 
-			await service.updateSchedule(sch)
+			await service.updateSchedule('123', schedule)
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
@@ -263,7 +263,7 @@ describe('ScheduleService', () => {
 				fetchMock.lastCall(
 					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 				)?.[1]?.body
-			).toEqual(JSON.stringify(sch.toJSON()))
+			).toEqual(JSON.stringify(schedule.toJSON()))
 		})
 	})
 
@@ -419,7 +419,7 @@ describe('ScheduleService', () => {
 		})
 
 		it('adds points to a schedule specified by string id', async () => {
-			const payload = { add: [HRef.make('345')] }
+			const payload = { add: HList.make([HRef.make('345')]) }
 
 			await service.updateSchedulePoints('123', payload)
 			expect(fetchMock.lastUrl()).toEqual(
@@ -437,7 +437,7 @@ describe('ScheduleService', () => {
 		})
 
 		it('adds points to a schedule specfied by HRef id', async () => {
-			const payload = { add: [HRef.make('345')] }
+			const payload = { add: HList.make([HRef.make('345')]) }
 
 			await service.updateSchedulePoints(HRef.make('123'), payload)
 			expect(fetchMock.lastUrl()).toEqual(
@@ -455,7 +455,7 @@ describe('ScheduleService', () => {
 		})
 
 		it('removes points from a schedule', async () => {
-			const payload = { remove: [HRef.make('345')] }
+			const payload = { remove: HList.make([HRef.make('345')]) }
 
 			await service.updateSchedulePoints('123', payload)
 			expect(fetchMock.lastUrl()).toEqual(
@@ -474,8 +474,8 @@ describe('ScheduleService', () => {
 
 		it('adds and removes the points from the schedule', async () => {
 			const payload = {
-				add: [HRef.make('abc')],
-				remove: [HRef.make('345')],
+				add: HList.make([HRef.make('abc')]),
+				remove: HList.make([HRef.make('345')]),
 			}
 
 			await service.updateSchedulePoints('123', payload)
@@ -594,7 +594,7 @@ describe('ScheduleService', () => {
 			const d1 = mockCalendar()
 			d1.remove('id')
 
-			const d2 = HDict.make(d1)
+			const d2 = HDict.make(d1) as Calendar
 			const payload = HGrid.make([d1, d2])
 
 			await service.createCalendars(payload)
@@ -642,9 +642,9 @@ describe('ScheduleService', () => {
 		})
 
 		it('updates a calendar specified by id', async () => {
-			const cal = mockCalendar()
+			const calendar = mockCalendar()
 
-			await service.updateCalendar(cal)
+			await service.updateCalendar('c123', calendar)
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
 			)
@@ -652,7 +652,7 @@ describe('ScheduleService', () => {
 				fetchMock.lastCall(
 					`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
 				)?.[1]?.body
-			).toEqual(JSON.stringify(cal.toJSON()))
+			).toEqual(JSON.stringify(calendar.toJSON()))
 		})
 	})
 

--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -570,43 +570,41 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	// describe('#createCalendars()', () => {
-	// 	beforeEach(() => {
-	// 		resp = HGrid.make(mockCalendar())
-	// 		prepareMock('POST', ScheduleServiceEndpoints.Calendars, resp)
-	// 	})
+	describe('#createCalendars()', () => {
+		beforeEach(() => {
+			resp = HGrid.make(mockCalendar())
+			prepareMock('POST', ScheduleServiceEndpoints.Calendars, resp)
+		})
 
-	// it('creates a single calendar', async () => {
-	// 	const payload = mockCalendar()
-	// 	payload.remove('id')
+		it('creates a single calendar', async () => {
+			const payload = mockCalendar()
+			payload.remove('id')
 
-	// 	console.log('yeet')
+			const response = HGrid.make(payload)
 
-	// 	const response = HGrid.make(payload)
+			await service.createCalendars(payload)
+			expect(
+				fetchMock.lastCall(
+					getUrl(ScheduleServiceEndpoints.Calendars)
+				)?.[1]?.body
+			).toEqual(JSON.stringify(response.toJSON()))
+		})
 
-	// 	await service.createCalendars(payload)
-	// 	expect(
-	// 		fetchMock.lastCall(
-	// 			getUrl(ScheduleServiceEndpoints.Calendars)
-	// 		)?.[1]?.body
-	// 	).toEqual(JSON.stringify(response.toJSON()))
-	// })
+		it('creates multiple calendars', async () => {
+			const d1 = mockCalendar()
+			d1.remove('id')
 
-	// it('creates multiple calendars', async () => {
-	// 	const d1 = mockCalendar()
-	// 	d1.remove('id')
+			const d2 = HDict.make(d1)
+			const payload = HGrid.make([d1, d2])
 
-	// 	const d2 = HDict.make(d1)
-	// 	const payload = HGrid.make([d1, d2])
-
-	// 	await service.createCalendars(payload)
-	// 	expect(
-	// 		fetchMock.lastCall(
-	// 			getUrl(ScheduleServiceEndpoints.Calendars)
-	// 		)?.[1]?.body
-	// 	).toEqual(JSON.stringify(payload.toJSON()))
-	// })
-	// })
+			await service.createCalendars(payload)
+			expect(
+				fetchMock.lastCall(
+					getUrl(ScheduleServiceEndpoints.Calendars)
+				)?.[1]?.body
+			).toEqual(JSON.stringify(payload.toJSON()))
+		})
+	})
 
 	describe('#readCalendarById()', () => {
 		beforeEach(() => {
@@ -658,30 +656,30 @@ describe('ScheduleService', () => {
 		})
 	})
 
-	// describe('#deleteCalendarById()', () => {
-	// 	beforeEach(() => {
-	// 		resp = mockCalendar()
-	// 		prepareMock(
-	// 			'DELETE',
-	// 			`${ScheduleServiceEndpoints.Calendars}/c123`,
-	// 			resp
-	// 		)
-	// 	})
+	describe('#deleteCalendarById()', () => {
+		beforeEach(() => {
+			resp = mockCalendar()
+			prepareMock(
+				'DELETE',
+				`${ScheduleServiceEndpoints.Calendars}/c123`,
+				resp
+			)
+		})
 
-	// 	it('deletes a particular calendar by string id', async () => {
-	// 		await service.deleteCalendarById('123')
-	// 		expect(fetchMock.lastUrl()).toEqual(
-	// 			`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
-	// 		)
-	// 	})
+		it('deletes a particular calendar by string id', async () => {
+			await service.deleteCalendarById('c123')
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
+			)
+		})
 
-	// 	it('deletes a particular calendar identified by HRef id', async () => {
-	// 		await service.deleteCalendarById(HRef.make('123'))
-	// 		expect(fetchMock.lastUrl()).toEqual(
-	// 			`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
-	// 		)
-	// 	})
-	// })
+		it('deletes a particular calendar identified by HRef id', async () => {
+			await service.deleteCalendarById(HRef.make('c123'))
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
+			)
+		})
+	})
 
 	describe('#readCalendarSchedulesById()', () => {
 		beforeEach(() => {

--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -3,107 +3,85 @@
  */
 
 import {
-	date,
-	dateTime,
-	dict,
 	HAYSON_MIME_TYPE,
+	HDate,
 	HDict,
 	HGrid,
+	HList,
+	HMarker,
+	HRef,
+	HStr,
 	Kind,
-	list,
-	MARKER,
-	num,
-	ref,
-	str,
-	time,
 } from 'haystack-core'
 import fetchMock from 'fetch-mock'
 import { clearFinCsrfTokens } from '../../../src/client/finCsrfFetch'
-import {
-	ScheduleService,
-	Schedule_Serv_EndPoints,
-	ScheduleMessages,
-} from '../../../src/client/schedules/ScheduleService'
+import { ScheduleService } from '../../../src/client/schedules/ScheduleService'
 import { Client } from '../../../src/client/Client'
+import {
+	Calendar,
+	SchedulablePoint,
+	Schedule,
+	ScheduleServiceEndpoints,
+	getHaystackServiceUrl,
+} from '../../../src'
+
+const mockSchedule = (): Schedule => {
+	return new HDict({
+		schedule: HMarker.make(),
+		id: HRef.make('123'),
+		dis: HStr.make('sample'),
+		kind: HStr.make(Kind.Number),
+		effectivePeriod: new HDict({
+			lowBound: HDate.make(new Date()),
+			upBound: HDate.make(new Date()),
+		}),
+	}) as Schedule
+}
+
+const mockPoint = (): SchedulablePoint => {
+	return new HDict({
+		id: HRef.make('p9089'),
+		dis: HStr.make('s-point'),
+		kind: Kind.Bool,
+		point: HMarker.make(),
+		schedulable: 12,
+		scheduleHRef: HRef.make('123'),
+	}) as SchedulablePoint
+}
+
+const mockCalendar = (): Calendar => {
+	return new HDict({
+		id: HRef.make('c123'),
+		dis: HStr.make('Cal-01'),
+		calendar: HMarker.make(),
+		entries: HList.make([
+			new HDict({
+				entryType: 'WeekNDay',
+				nthWeek: 1,
+				dayOfWeek: 2,
+			}),
+		]),
+	}) as Calendar
+}
 
 describe('ScheduleService', () => {
-	const SampleScheduleObj = () => {
-		return dict({
-			schedule: MARKER,
-			id: ref('123'),
-			dis: str('sample'),
-			mod: dateTime(new Date()),
-			kind: str(Kind.Number),
-			curVal: num(20),
-			nextVal: num(30),
-			nextChange: dateTime(new Date()),
-		})
-	}
-
-	const SampleEvent = () => {
-		return dict({
-			dis: str('event 01'),
-			type: str('exception'),
-			start: time('08:30:00'),
-			end: time('15:30:00'),
-			val: num(20),
-			priority: num(5),
-			status: str('ok'),
-			period: dict({
-				type: str('date'),
-				val: date('2020-10-23'),
-			}),
-		})
-	}
-
-	const SamplePoint = () => {
-		return dict({
-			id: ref('p9089'),
-			schedulable: num(12),
-			scheduleRef: ref('123'),
-		})
-	}
-
-	const SampleCalendar = () => {
-		return dict({
-			id: ref('c123'),
-			dis: str('Cal-01'),
-			mod: dateTime(new Date()),
-			entries: list([
-				dict({
-					val: num(10),
-					period: dict({
-						type: str('date'),
-						val: date('2020-10-23'),
-					}),
-				}),
-			]),
-		})
-	}
-
-	let resp: HDict | HGrid
+	let resp: HDict | HGrid | HRef
 	let service: ScheduleService
 
 	const baseUrl = 'http://localhost:8080'
-	const ABS_DEFS_PATH = `${baseUrl}/api/sys/eval`
-
-	function prepareFetch(): void {
-		const grid = HGrid.make({ rows: [{ foo: true }] })
-
-		fetchMock.reset().post(ABS_DEFS_PATH, grid.toZinc())
-
-		service = new ScheduleService(
-			new Client({ base: new URL(baseUrl), fetch })
-		)
-	}
 
 	function prepareMock(
 		verb: string,
-		endpoint: string,
+		endpoint: ScheduleServiceEndpoints | string,
 		resp: HDict | HGrid
 	): void {
-		fetchMock.mock(
-			`begin:${baseUrl}/api/haystack/demo/${endpoint}`,
+		fetchMock.reset().mock(
+			`begin:${getHaystackServiceUrl({
+				origin: baseUrl,
+				pathPrefix: '',
+				project: 'demo',
+				path: endpoint,
+			})}`,
 			{
 				body: resp.toJSON(),
 				headers: { 'content-type': HAYSON_MIME_TYPE },
@@ -118,72 +96,74 @@ describe('ScheduleService', () => {
 
 	beforeEach(function (): void {
 		clearFinCsrfTokens()
-		prepareFetch()
 	})
 
-	function getUrl(path: string): string {
-		return `${baseUrl}/api/haystack/demo/${path}`
-	}
+	const getUrl = (path: string): string =>
+		`${getHaystackServiceUrl({
+			origin: baseUrl,
+			pathPrefix: '',
+			project: 'demo',
+			path,
+		})}`
 
-	describe('#readSchedules()', () => {
+	// ********************************
+	// Start Schedule Endpoint Testing
+	// ********************************
+
+	describe('#readAllSchedules()', () => {
 		beforeEach((): void => {
-			resp = HGrid.make(SampleScheduleObj())
-			prepareMock('get', Schedule_Serv_EndPoints.Schedules, resp)
+			resp = HGrid.make(mockSchedule())
+			prepareMock('GET', ScheduleServiceEndpoints.Schedules, resp)
 		})
 
 		it('fetches the schedule with no params/options', async () => {
-			await service.readSchedules()
+			await service.readAllSchedules()
 			expect(fetchMock.lastUrl()).toEqual(
-				getUrl(Schedule_Serv_EndPoints.Schedules)
+				getUrl(ScheduleServiceEndpoints.Schedules)
 			)
 		})
 
 		it('fetches the schedules based on a filter', async () => {
-			await service.readSchedules({ filter: 'dis=="sample"' })
+			await service.readAllSchedules({ filter: 'dis=="sample"' })
+
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(
-					Schedule_Serv_EndPoints.Schedules
+					ScheduleServiceEndpoints.Schedules
 				)}?filter=${encodeURIComponent('dis=="sample"')}`
 			)
 		})
 
 		it('fetches the schedules and limits them to 1 item', async () => {
-			await service.readSchedules({ options: { limit: 1 } })
+			await service.readAllSchedules({ limit: 1 })
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedules)}?limit=1`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}?limit=1`
 			)
 		})
 
 		it('fetches the schedules and asks for only some columns/props specified', async () => {
-			await service.readSchedules({
-				options: { columns: ['dis', 'mod'] },
-			})
+			await service.readAllSchedules({ columns: ['dis', 'mod'] })
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(
-					Schedule_Serv_EndPoints.Schedules
+					ScheduleServiceEndpoints.Schedules
 				)}?columns=${encodeURI('dis|mod')}`
 			)
 		})
 
 		it('fetches the schedule and sorts the result by some column names', async () => {
-			await service.readSchedules({
-				options: { sort: ['dis', 'mod'] },
-			})
+			await service.readAllSchedules({ sort: ['dis', 'mod'] })
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedules)}?sort=${encodeURI(
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}?sort=${encodeURI(
 					'dis|mod'
 				)}`
 			)
 		})
 
 		it('fetches the schedules with all query params', async () => {
-			await service.readSchedules({
+			await service.readAllSchedules({
+				columns: ['dis', 'mod'],
+				limit: 2,
+				sort: ['dis', 'id'],
 				filter: 'events < 5',
-				options: {
-					columns: ['dis', 'mod'],
-					limit: 2,
-					sort: ['dis', 'id'],
-				},
 			})
 
 			const expected = `columns=${encodeURI(
@@ -193,36 +173,37 @@ describe('ScheduleService', () => {
 			)}`
 
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedules)}?${expected}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}?${expected}`
 			)
 		})
 	})
 
-	describe('#createSchedule()', () => {
+	describe('#createSchedules()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleScheduleObj())
-			prepareMock('post', Schedule_Serv_EndPoints.Schedules, resp)
+			resp = HGrid.make(mockSchedule())
+			prepareMock('POST', ScheduleServiceEndpoints.Schedules, resp)
 		})
 
 		it('creates a single schedule', async () => {
-			const payload = SampleScheduleObj()
+			const payload = mockSchedule()
 			payload.remove('id')
 			payload.remove('schedule')
-			payload.remove('mod')
+
+			// API always returns HGrid
+			const response = HGrid.make(payload)
 
 			await service.createSchedules(payload)
 			expect(
 				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Schedules)
+					getUrl(ScheduleServiceEndpoints.Schedules)
 				)?.[1]?.body
-			).toEqual(JSON.stringify(payload.toJSON()))
+			).toEqual(JSON.stringify(response.toJSON()))
 		})
 
 		it('creates multiple schedules', async () => {
-			const d1 = SampleScheduleObj()
+			const d1 = mockSchedule()
 			d1.remove('id')
 			d1.remove('schedule')
-			d1.remove('mod')
 
 			const d2 = HDict.make(d1)
 			const payload = HGrid.make([d1, d2])
@@ -230,7 +211,7 @@ describe('ScheduleService', () => {
 			await service.createSchedules(payload)
 			expect(
 				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Schedules)
+					getUrl(ScheduleServiceEndpoints.Schedules)
 				)?.[1]?.body
 			).toEqual(JSON.stringify(payload.toJSON()))
 		})
@@ -238,10 +219,10 @@ describe('ScheduleService', () => {
 
 	describe('#readScheduleById()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleScheduleObj())
+			resp = mockSchedule()
 			prepareMock(
-				'get',
-				Schedule_Serv_EndPoints.Schedule.replace(':id', '123'),
+				'GET',
+				`${ScheduleServiceEndpoints.Schedules}/123`,
 				resp
 			)
 		})
@@ -249,412 +230,332 @@ describe('ScheduleService', () => {
 		it('reads a particular schedule by string id', async () => {
 			await service.readScheduleById('123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
 		})
 
-		it('reads a particular schedule by ref', async () => {
-			await service.readScheduleById(ref('123'))
+		it('reads a particular schedule by HRef', async () => {
+			await service.readScheduleById(HRef.make('123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
 		})
 	})
 
 	describe('#updateSchedule()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleScheduleObj())
+			resp = mockSchedule()
 			prepareMock(
-				'patch',
-				Schedule_Serv_EndPoints.Schedule.replace(':id', '123'),
+				'PATCH',
+				`${ScheduleServiceEndpoints.Schedules}/123`,
 				resp
 			)
 		})
 
 		it('updates a schedule specified by an id', async () => {
-			const sch = SampleScheduleObj()
+			const sch = mockSchedule()
 
 			await service.updateSchedule(sch)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
 			expect(
 				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-						':id',
-						'123'
-					)
+					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(sch.toJSON()))
 		})
-
-		it('throws error if the rec does not have an id', async () => {
-			const sch = SampleScheduleObj()
-			sch.remove('id')
-
-			expect(service.updateSchedule(sch)).rejects.toEqual(
-				new Error(ScheduleMessages.BadRequest)
-			)
-		})
 	})
 
-	describe('#deleteSchedule()', () => {
+	describe('#deleteScheduleById()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleScheduleObj())
+			resp = mockSchedule()
 			prepareMock(
-				'delete',
-				Schedule_Serv_EndPoints.Schedule.replace(':id', '123'),
+				'DELETE',
+				`${ScheduleServiceEndpoints.Schedules}/123`,
 				resp
 			)
 		})
 
 		it('deletes a particular schedule by string id', async () => {
-			await service.deleteSchedule('123')
+			await service.deleteScheduleById('123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
 		})
 
-		it('deletes a particular schedule by ref', async () => {
-			await service.deleteSchedule(ref('123'))
+		it('deletes a particular schedule by HRef', async () => {
+			await service.deleteScheduleById(HRef.make('123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Schedule).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123`
 			)
 		})
 	})
 
-	describe('#readScheduleEvents()', () => {
+	describe('#readScheduleCalendarsById()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleEvent())
+			resp = HGrid.make(mockCalendar())
 			prepareMock(
 				'get',
-				Schedule_Serv_EndPoints.Events.replace(':id', '123'),
+				`${ScheduleServiceEndpoints.Schedules}/123/calendars`,
 				resp
 			)
 		})
 
 		it('gets the events for schedule id specified as string', async () => {
-			await service.readScheduleEvents('123')
+			await service.readScheduleCalendarsById('123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/calendars`
 			)
 		})
 
-		it('gets the events for schedule id specified as ref', async () => {
-			await service.readScheduleEvents(ref('123'))
+		it('gets the events for schedule id specified as HRef', async () => {
+			await service.readScheduleCalendarsById(HRef.make('123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/calendars`
 			)
 		})
 	})
 
-	describe('#updateScheduleEvents()', () => {
+	// ***************************************
+	// Start Schedule/Points Endpoint Testing
+	// ***************************************
+
+	describe('#readSchedulablePoints()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleEvent())
+			resp = HGrid.make(mockPoint())
 			prepareMock(
-				'patch',
-				Schedule_Serv_EndPoints.Events.replace(':id', '123'),
-				resp
-			)
-		})
-
-		it('updates the events for schedule id specified as string', async () => {
-			const payload = HGrid.make(SampleEvent())
-			await service.updateScheduleEvents('123', payload)
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-					':id',
-					'123'
-				)}`
-			)
-			expect(
-				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-						':id',
-						'123'
-					)}`
-				)?.[1]?.body
-			).toEqual(JSON.stringify(payload.toJSON()))
-		})
-
-		it('gets the events for schedule id specified as ref', async () => {
-			const payload = HGrid.make(SampleEvent())
-			await service.updateScheduleEvents('123', payload)
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-					':id',
-					'123'
-				)}`
-			)
-			expect(
-				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Events).replace(
-						':id',
-						'123'
-					)}`
-				)?.[1]?.body
-			).toEqual(JSON.stringify(payload.toJSON()))
-		})
-	})
-
-	describe('#readSchedulePoints()', () => {
-		beforeEach(() => {
-			resp = HGrid.make(SamplePoint())
-			prepareMock(
-				'get',
-				Schedule_Serv_EndPoints.Points.replace(':id', '123'),
+				'GET',
+				`${ScheduleServiceEndpoints.Schedules}/123/points`,
 				resp
 			)
 		})
 
 		it('gets the points for schedule id specified as string', async () => {
-			await service.readSchedulePoints('123')
+			await service.readSchedulablePoints('123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 			)
 		})
 
-		it('gets the points for schedule id specified as ref', async () => {
-			await service.readSchedulePoints(ref('123'))
+		it('gets the points for schedule id specified as HRef', async () => {
+			await service.readSchedulablePoints(HRef.make('123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
+			)
+		})
+
+		it('fetches the schedulable points based on a filter', async () => {
+			await service.readSchedulablePoints('123', {
+				filter: 'dis=="sample"',
+			})
+
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/points?filter=${encodeURIComponent('dis=="sample"')}`
+			)
+		})
+
+		it('fetches the schedulable points and limits them to 1 item', async () => {
+			await service.readSchedulablePoints('123', { limit: 1 })
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/points?limit=1`
+			)
+		})
+
+		it('fetches the scheduluable points and asks for only some columns/props specified', async () => {
+			await service.readSchedulablePoints('123', {
+				columns: ['dis', 'mod'],
+			})
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/points?columns=${encodeURI('dis|mod')}`
+			)
+		})
+
+		it('fetches the scheduluable points and sorts the result by some column names', async () => {
+			await service.readSchedulablePoints('123', { sort: ['dis', 'mod'] })
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/points?sort=${encodeURI('dis|mod')}`
+			)
+		})
+
+		it('fetches the scheduluable points with all query params', async () => {
+			await service.readSchedulablePoints('123', {
+				columns: ['dis', 'mod'],
+				limit: 2,
+				sort: ['dis', 'id'],
+				filter: 'events < 5',
+			})
+
+			const expected = `columns=${encodeURI(
+				'dis|mod'
+			)}&limit=2&sort=${encodeURI('dis|id')}&filter=${encodeURIComponent(
+				'events < 5'
+			)}`
+
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/points?${expected}`
 			)
 		})
 	})
 
 	describe('#updateSchedulePoints()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SamplePoint())
+			resp = HGrid.make(mockPoint())
 			prepareMock(
-				'patch',
-				Schedule_Serv_EndPoints.Points.replace(':id', '123'),
+				'PATCH',
+				`${ScheduleServiceEndpoints.Schedules}/123/points`,
 				resp
 			)
 		})
 
-		it('adds points to a schedule specfied my string id', async () => {
-			const payload = { add: [ref('345')] }
+		it('adds points to a schedule specified by string id', async () => {
+			const payload = { add: [HRef.make('345')] }
 
 			await service.updateSchedulePoints('123', payload)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 			)
 
-			const expected = dict({
-				add: list([ref('345')]),
+			const expected = HDict.make({
+				add: HList.make([HRef.make('345')]),
 			})
 			expect(
 				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-						':id',
-						'123'
-					)}`
+					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(expected.toJSON()))
 		})
 
-		it('adds points to a schedule specfied my ref id', async () => {
-			const payload = { add: [ref('345')] }
+		it('adds points to a schedule specfied by HRef id', async () => {
+			const payload = { add: [HRef.make('345')] }
 
-			await service.updateSchedulePoints(ref('123'), payload)
+			await service.updateSchedulePoints(HRef.make('123'), payload)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 			)
 
-			const expected = dict({
-				add: list([ref('345')]),
+			const expected = HDict.make({
+				add: HList.make([HRef.make('345')]),
 			})
 			expect(
 				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-						':id',
-						'123'
-					)}`.replace('begin:', '')
+					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(expected.toJSON()))
 		})
 
-		it('removes points to a schedule', async () => {
-			const payload = { remove: [ref('345')] }
+		it('removes points from a schedule', async () => {
+			const payload = { remove: [HRef.make('345')] }
 
 			await service.updateSchedulePoints('123', payload)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 			)
 
-			const expected = dict({
-				remove: list([ref('345')]),
+			const expected = HDict.make({
+				remove: HList.make([HRef.make('345')]),
 			})
 			expect(
 				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-						':id',
-						'123'
-					)}`
+					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(expected.toJSON()))
 		})
 
 		it('adds and removes the points from the schedule', async () => {
-			const payload = { add: [ref('abc')], remove: [ref('345')] }
+			const payload = {
+				add: [HRef.make('abc')],
+				remove: [HRef.make('345')],
+			}
 
 			await service.updateSchedulePoints('123', payload)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 			)
 
-			const expected = dict({
-				add: list([ref('abc')]),
-				remove: list([ref('345')]),
+			const expected = HDict.make({
+				add: HList.make([HRef.make('abc')]),
+				remove: HList.make([HRef.make('345')]),
 			})
 			expect(
 				fetchMock.lastCall(
-					`${getUrl(Schedule_Serv_EndPoints.Points).replace(
-						':id',
-						'123'
-					)}`
+					`${getUrl(ScheduleServiceEndpoints.Schedules)}/123/points`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(expected.toJSON()))
 		})
-
-		it('returns empty array when the nothing is specified to be added ot removed', async () => {
-			const resp = await service.updateSchedulePoints(ref('123'), {
-				add: [],
-				remove: [],
-			})
-			expect(resp).toEqual([])
-		})
 	})
 
-	describe('#getScheduleCalendars()', () => {
-		beforeEach(() => {
-			resp = HGrid.make(SampleCalendar())
-			prepareMock(
-				'get',
-				Schedule_Serv_EndPoints.ScheduleCalendars.replace(':id', '123'),
-				resp
-			)
-		})
+	// ***********************
+	// Start Calendar Testing
+	// ***********************
 
-		it('returns all the calendars for a schedule identified by string id', async () => {
-			await service.getScheduleCalendars('123')
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.ScheduleCalendars).replace(
-					':id',
-					'123'
-				)}`
-			)
-		})
-
-		it('returns all the calendars for a schedule identified by ref id', async () => {
-			await service.getScheduleCalendars(ref('123'))
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.ScheduleCalendars).replace(
-					':id',
-					'123'
-				)}`
-			)
-		})
-	})
-
-	describe('#readCalendars()', () => {
+	describe('#readAllCalendars()', () => {
 		beforeEach((): void => {
-			resp = HGrid.make(SampleCalendar())
-			prepareMock('get', Schedule_Serv_EndPoints.Calendars, resp)
+			resp = HGrid.make(mockCalendar())
+			prepareMock('GET', ScheduleServiceEndpoints.Calendars, resp)
 		})
 
 		it('fetches the calendars with no params/options', async () => {
-			await service.readCalendars()
+			await service.readAllCalendars()
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendars)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}`
 			)
 		})
 
 		it('fetches the calendars based on a filter', async () => {
-			await service.readCalendars({ filter: 'dis=="sample"' })
+			await service.readAllCalendars({ filter: 'dis=="sample"' })
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(
-					Schedule_Serv_EndPoints.Calendars
+					ScheduleServiceEndpoints.Calendars
 				)}?filter=${encodeURIComponent('dis=="sample"')}`
 			)
 		})
 
 		it('fetches the calendars and limits them to 1 item', async () => {
-			await service.readCalendars({ options: { limit: 1 } })
+			await service.readAllCalendars({ limit: 1 })
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendars)}?limit=1`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}?limit=1`
 			)
 		})
 
 		it('fetches the calendars and asks for only some columns/props specified', async () => {
-			await service.readCalendars({
-				options: { columns: ['dis', 'mod'] },
+			await service.readAllCalendars({
+				columns: ['dis', 'mod'],
 			})
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(
-					Schedule_Serv_EndPoints.Calendars
+					ScheduleServiceEndpoints.Calendars
 				)}?columns=${encodeURI('dis|mod')}`
 			)
 		})
 
 		it('fetches the calendars and sorts the result by some column names', async () => {
-			await service.readCalendars({
-				options: { sort: ['dis', 'mod'] },
+			await service.readAllCalendars({
+				sort: ['dis', 'mod'],
 			})
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendars)}?sort=${encodeURI(
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}?sort=${encodeURI(
 					'dis|mod'
 				)}`
 			)
 		})
 
 		it('fetches the calendars with all query params', async () => {
-			await service.readCalendars({
+			await service.readAllCalendars({
+				columns: ['dis', 'mod'],
+				limit: 2,
+				sort: ['dis', 'id'],
 				filter: 'area > 20',
-				options: {
-					columns: ['dis', 'mod'],
-					limit: 2,
-					sort: ['dis', 'id'],
-				},
 			})
 
 			const expected = `columns=${encodeURI(
@@ -664,53 +565,55 @@ describe('ScheduleService', () => {
 			)}`
 
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendars)}?${expected}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}?${expected}`
 			)
 		})
 	})
 
-	describe('#createCalendars()', () => {
-		beforeEach(() => {
-			resp = HGrid.make(SampleCalendar())
-			prepareMock('post', Schedule_Serv_EndPoints.Calendars, resp)
-		})
+	// describe('#createCalendars()', () => {
+	// 	beforeEach(() => {
+	// 		resp = HGrid.make(mockCalendar())
+	// 		prepareMock('POST', ScheduleServiceEndpoints.Calendars, resp)
+	// 	})
 
-		it('creates a single calendar', async () => {
-			const payload = SampleCalendar()
-			payload.remove('id')
-			payload.remove('mod')
+	// it('creates a single calendar', async () => {
+	// 	const payload = mockCalendar()
+	// 	payload.remove('id')
 
-			await service.createCalendars(payload)
-			expect(
-				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Calendars)
-				)?.[1]?.body
-			).toEqual(JSON.stringify(payload.toJSON()))
-		})
+	// 	console.log('yeet')
 
-		it('creates multiple calendars', async () => {
-			const d1 = SampleCalendar()
-			d1.remove('id')
-			d1.remove('mod')
+	// 	const response = HGrid.make(payload)
 
-			const d2 = HDict.make(d1)
-			const payload = HGrid.make([d1, d2])
+	// 	await service.createCalendars(payload)
+	// 	expect(
+	// 		fetchMock.lastCall(
+	// 			getUrl(ScheduleServiceEndpoints.Calendars)
+	// 		)?.[1]?.body
+	// 	).toEqual(JSON.stringify(response.toJSON()))
+	// })
 
-			await service.createCalendars(payload)
-			expect(
-				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Calendars)
-				)?.[1]?.body
-			).toEqual(JSON.stringify(payload.toJSON()))
-		})
-	})
+	// it('creates multiple calendars', async () => {
+	// 	const d1 = mockCalendar()
+	// 	d1.remove('id')
+
+	// 	const d2 = HDict.make(d1)
+	// 	const payload = HGrid.make([d1, d2])
+
+	// 	await service.createCalendars(payload)
+	// 	expect(
+	// 		fetchMock.lastCall(
+	// 			getUrl(ScheduleServiceEndpoints.Calendars)
+	// 		)?.[1]?.body
+	// 	).toEqual(JSON.stringify(payload.toJSON()))
+	// })
+	// })
 
 	describe('#readCalendarById()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleCalendar())
+			resp = mockCalendar()
 			prepareMock(
-				'get',
-				Schedule_Serv_EndPoints.Calendar.replace(':id', '123'),
+				'GET',
+				`${ScheduleServiceEndpoints.Calendars}/123`,
 				resp
 			)
 		})
@@ -718,122 +621,89 @@ describe('ScheduleService', () => {
 		it('reads a particular calendar by string id', async () => {
 			await service.readCalendarById('123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/123`
 			)
 		})
 
-		it('reads a particular calendar by ref', async () => {
-			await service.readCalendarById(ref('123'))
+		it('reads a particular calendar by HRef', async () => {
+			await service.readCalendarById(HRef.make('123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/123`
 			)
 		})
 	})
 
 	describe('#updateCalendar()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleCalendar())
+			resp = mockCalendar()
 			prepareMock(
-				'patch',
-				Schedule_Serv_EndPoints.Calendar.replace(':id', 'c123'),
+				'PATCH',
+				`${ScheduleServiceEndpoints.Calendars}/c123`,
 				resp
 			)
 		})
 
-		it('updates a calendar specified by an id', async () => {
-			const cal = SampleCalendar()
+		it('updates a calendar specified by id', async () => {
+			const cal = mockCalendar()
 
 			await service.updateCalendar(cal)
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-					':id',
-					'c123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
 			)
 			expect(
 				fetchMock.lastCall(
-					getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-						':id',
-						'c123'
-					)
+					`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
 				)?.[1]?.body
 			).toEqual(JSON.stringify(cal.toJSON()))
 		})
-
-		it('throws error if the rec does not have an id', async () => {
-			const cal = SampleCalendar()
-			cal.remove('id')
-
-			expect(service.updateCalendar(cal)).rejects.toEqual(
-				new Error(ScheduleMessages.BadRequest)
-			)
-		})
 	})
 
-	describe('#deleteCalendar()', () => {
+	// describe('#deleteCalendarById()', () => {
+	// 	beforeEach(() => {
+	// 		resp = mockCalendar()
+	// 		prepareMock(
+	// 			'DELETE',
+	// 			`${ScheduleServiceEndpoints.Calendars}/c123`,
+	// 			resp
+	// 		)
+	// 	})
+
+	// 	it('deletes a particular calendar by string id', async () => {
+	// 		await service.deleteCalendarById('123')
+	// 		expect(fetchMock.lastUrl()).toEqual(
+	// 			`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
+	// 		)
+	// 	})
+
+	// 	it('deletes a particular calendar identified by HRef id', async () => {
+	// 		await service.deleteCalendarById(HRef.make('123'))
+	// 		expect(fetchMock.lastUrl()).toEqual(
+	// 			`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123`
+	// 		)
+	// 	})
+	// })
+
+	describe('#readCalendarSchedulesById()', () => {
 		beforeEach(() => {
-			resp = HGrid.make(SampleCalendar())
+			resp = HGrid.make(mockSchedule())
 			prepareMock(
-				'delete',
-				Schedule_Serv_EndPoints.Calendar.replace(':id', '123'),
-				resp
-			)
-		})
-
-		it('deletes a particular calendar indentified by string id', async () => {
-			await service.deleteCalendar('123')
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-					':id',
-					'123'
-				)}`
-			)
-		})
-
-		it('deletes a particular calendar identified by ref id', async () => {
-			await service.deleteCalendar(ref('123'))
-			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.Calendar).replace(
-					':id',
-					'123'
-				)}`
-			)
-		})
-	})
-
-	describe('#getCalendarSchedules()', () => {
-		beforeEach(() => {
-			resp = HGrid.make(SampleScheduleObj())
-			prepareMock(
-				'get',
-				Schedule_Serv_EndPoints.CalendarSchedules.replace(':id', '123'),
+				'GET',
+				`${ScheduleServiceEndpoints.Calendars}/c123`,
 				resp
 			)
 		})
 
 		it('returns all the schedules for a calendar identified by string id', async () => {
-			await service.getCalendarSchedules('123')
+			await service.readCalendarSchedulesById('c123')
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.CalendarSchedules).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123/schedules`
 			)
 		})
 
-		it('returns all the schedules for a calendar identified by ref id', async () => {
-			await service.getCalendarSchedules(ref('123'))
+		it('returns all the schedules for a calendar identified by HRef id', async () => {
+			await service.readCalendarSchedulesById(HRef.make('c123'))
 			expect(fetchMock.lastUrl()).toEqual(
-				`${getUrl(Schedule_Serv_EndPoints.CalendarSchedules).replace(
-					':id',
-					'123'
-				)}`
+				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123/schedules`
 			)
 		})
 	})

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -227,7 +227,7 @@ export class ScheduleService {
 	 */
 	public async createCalendars(calendars: Calendar | HDict | HGrid) {
 		return fetchVal<HGrid<Calendar>>(
-			this.#schedulesUrl,
+			this.#calendarsUrl,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'POST',

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -2,18 +2,16 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
-import { HDict, HGrid, HList, HRef } from 'haystack-core'
+import { HGrid, HRef } from 'haystack-core'
 import {
-	// ScheduleReadOptions,
 	SchedulePointUpdate,
 	Schedule,
 	Calendar,
-	CalendarEntry,
 	ScheduleReadOptions,
+	SchedulablePoint,
 } from './types'
 import { fetchVal } from '../fetchVal'
 import { ClientServiceConfig } from '../ClientServiceConfig'
-import { ScheduleEvent, SchedulePoint } from './types'
 import { encodeQuery } from '../../util/http'
 import { dictsToGrid } from '../../util/hval'
 
@@ -55,7 +53,7 @@ export class ScheduleService {
 	 * @returns The HGrid result of the schedule read function.
 	 */
 	public async readAllSchedules(options?: ScheduleReadOptions) {
-		return fetchVal<HGrid<T>>(
+		return fetchVal<HGrid<Schedule>>(
 			`${this.#schedulesUrl}${encodeQuery({
 				...(options ?? {}),
 			})}`,
@@ -69,11 +67,11 @@ export class ScheduleService {
 	/**
 	 * Creates single or multiple schedules.
 	 *
-	 * @param schedules HDict | HGrid
+	 * @param schedules Schedule | HGrid of Schedule
 	 * @returns A grid containing the created schedules.
 	 */
-	public async createSchedules(schedules: HDict | HGrid) {
-		return fetchVal<HGrid<T>>(
+	public async createSchedules(schedules: Schedule | HGrid<Schedule>) {
+		return fetchVal<HGrid<Schedule>>(
 			this.#schedulesUrl,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -91,7 +89,7 @@ export class ScheduleService {
 	 * @returns The schedule record.
 	 */
 	public async readScheduleById(id: string | HRef) {
-		return fetchVal<HDict<T>>(
+		return fetchVal<Schedule>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -105,8 +103,8 @@ export class ScheduleService {
 	 * @param schedule Schedule | HDict
 	 * @returns The updated schedule record.
 	 */
-	public async updateSchedule(schedule: HDict) {
-		return fetchVal<HDict<T>>(
+	public async updateSchedule(schedule: Schedule) {
+		return fetchVal<Schedule>(
 			`${this.#schedulesUrl}/${schedule.id?.value ?? ''}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -124,7 +122,7 @@ export class ScheduleService {
 	 * @returns The deleted schedule.
 	 */
 	public async deleteScheduleById(id: string | HRef) {
-		return fetchVal<T>(
+		return fetchVal<Schedule>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -140,10 +138,8 @@ export class ScheduleService {
 	 * @param id string | HRef
 	 * @returns HGrid<Calendar>
 	 */
-	public async readScheduleCalendarsById(
-		id: string | HRef
-	): Promise<HGrid<CalendarEntry>> {
-		return fetchVal<HGrid<CalendarEntry>>(
+	public async readScheduleCalendarsById(id: string | HRef) {
+		return fetchVal<HGrid<Calendar>>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}/calendars`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -156,13 +152,13 @@ export class ScheduleService {
 	 *
 	 * @param id string | HRef
 	 * @param options ScheduleReadOptions & { omit?: string[] }
-	 * @returns HGrid<SchedulablePoints>
+	 * @returns HGrid of SchedulablePoints
 	 */
 	public async readSchedulablePoints(
 		id: string | HRef,
 		options?: ScheduleReadOptions
-	): Promise<HGrid<T>> {
-		return fetchVal<HGrid<T>>(
+	) {
+		return fetchVal<HGrid<SchedulablePoint>>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}/points/${encodeQuery({
 				...(options ?? {}),
 			})}`,
@@ -178,13 +174,13 @@ export class ScheduleService {
 	 *
 	 * @param id string | HRef
 	 * @param pointUpdates SchedulePointUpdate
-	 * @returns HGrid with all points that were added or removed.
+	 * @returns HGrid with all SchedulablePoint(s) that were added or removed.
 	 */
 	public async updateSchedulePoints(
 		id: string | HRef,
 		pointUpdates: SchedulePointUpdate
 	) {
-		return fetchVal<HGrid<T>>(
+		return fetchVal<HGrid<SchedulablePoint>>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}/points/`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -206,7 +202,7 @@ export class ScheduleService {
 	 * @returns The HGrid result of the calendar read function.
 	 */
 	public async readAllCalendars(options?: ScheduleReadOptions) {
-		return fetchVal<HGrid<T>>(
+		return fetchVal<HGrid<Calendar>>(
 			`${this.#calendarsUrl}${encodeQuery({
 				...(options ?? {}),
 			})}`,
@@ -220,11 +216,11 @@ export class ScheduleService {
 	/**
 	 * Creates single or multiple calendars.
 	 *
-	 * @param calendars HDict | HGrid
+	 * @param calendars Calendar | HGrid of Calendar
 	 * @returns A grid containing the created calendar(s).
 	 */
-	public async createCalendars(calendars: HDict | HGrid) {
-		return fetchVal<HGrid<T>>(
+	public async createCalendars(calendars: Calendar | HGrid<Calendar>) {
+		return fetchVal<HGrid<Calendar>>(
 			this.#schedulesUrl,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -242,7 +238,7 @@ export class ScheduleService {
 	 * @returns The calendar record.
 	 */
 	public async readCalendarById(id: string | HRef) {
-		return fetchVal<HDict<T>>(
+		return fetchVal<Calendar>(
 			`${this.#calendarsUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -253,11 +249,11 @@ export class ScheduleService {
 	/**
 	 * Updates a calendar.
 	 *
-	 * @param schedule Calendar | HDict
+	 * @param schedule Calendar
 	 * @returns The updated calendar record.
 	 */
-	public async updateCalendar(calendar: HDict) {
-		return fetchVal<HDict<T>>(
+	public async updateCalendar(calendar: Calendar) {
+		return fetchVal<Calendar>(
 			`${this.#calendarsUrl}/${calendar.id?.value ?? ''}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -275,7 +271,7 @@ export class ScheduleService {
 	 * @returns The deleted calendar.
 	 */
 	public async deleteCalendarById(id: string | HRef) {
-		return fetchVal<T>(
+		return fetchVal<Calendar>(
 			`${this.#calendarsUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
@@ -291,10 +287,8 @@ export class ScheduleService {
 	 * @param id string | HRef
 	 * @returns HGrid<Schedule>
 	 */
-	public async readCalendarSchedulesById(
-		id: string | HRef
-	): Promise<HGrid<CalendarEntry>> {
-		return fetchVal<HGrid<CalendarEntry>>(
+	public async readCalendarSchedulesById(id: string | HRef) {
+		return fetchVal<HGrid<Schedule>>(
 			`${this.#schedulesUrl}/${HRef.make(id).value}/schedules`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -4,37 +4,46 @@
 
 import { HDict, HGrid, HList, HRef } from 'haystack-core'
 import {
-	ScheduleReadOptions,
+	// ScheduleReadOptions,
 	SchedulePointUpdate,
 	Schedule,
 	Calendar,
+	CalendarEntry,
 } from './types'
 import { fetchVal } from '../fetchVal'
 import { ClientServiceConfig } from '../ClientServiceConfig'
 import { ScheduleEvent, SchedulePoint } from './types'
 import { encodeQuery } from '../../util/http'
+import { dictsToGrid } from '../../util/hval'
 
-export const Schedule_Serv_EndPoints = {
-	Schedules: 'schedules',
-	Schedule: 'schedules/:id',
-	Events: 'schedules/:id/events',
-	Points: 'schedules/:id/points',
-	ScheduleCalendars: 'schedules/:id/calendars',
-	Calendars: 'calendars',
-	Calendar: 'calendars/:id',
-	CalendarSchedules: 'calendars/:id/schedules',
-}
-
-const ID = ':id'
-
-export const enum ScheduleMessages {
-	BadRequest = 'Bad Request',
-	Invalid = 'Invalid Result',
-}
-
-export type ScheduleReadFilterOptions = {
+/**
+ * Options for reading Schedules and Calendars.
+ */
+export type ScheduleReadOptions = {
+	/**
+	 * If defined, Gets the functions filtered by a Haystack filter
+	 */
 	filter?: string
-	options?: ScheduleReadOptions
+
+	/**
+	 * If defined, specifies the name of the tag/prop by which the returned function records are sorted in ascending order.
+	 */
+	sort?: string[]
+
+	/**
+	 * If defined, specifies the max number of function records that will be returned by the read
+	 */
+	limit?: number
+
+	/**
+	 * If defined, limit the number of columns sent back in the response.
+	 */
+	columns?: string[]
+
+	/**
+	 * Omit the specified columns from the response.
+	 */
+	omit?: string[]
 }
 
 export class ScheduleService {
@@ -44,131 +53,108 @@ export class ScheduleService {
 	readonly #serviceConfig: ClientServiceConfig
 
 	/**
+	 * The url for the calendars service.
+	 */
+	readonly #calendarsUrl: string
+
+	/**
+	 * The url for the schedules service.
+	 */
+	readonly #schedulesUrl: string
+
+	/**
 	 * Constructs a new record service object.
 	 *
 	 * @param serviceConfig Service configuration.
 	 */
 	public constructor(serviceConfig: ClientServiceConfig) {
 		this.#serviceConfig = serviceConfig
+		this.#calendarsUrl = serviceConfig.getHaystackServiceUrl('calendars')
+		this.#schedulesUrl = serviceConfig.getHaystackServiceUrl('schedules')
 	}
 
-	/**
-	 * Reads the schedules via a filter/options. If the filter is not provided, will get all the schedules
-	 *
-	 * @param readOpts.filter The filter string by which to get the schedules.
-	 * @param readOpts.options Optional options when reading via filter
-	 * @param readOpts.options.columns Specifies the name(s) of the column(s) to get. If specified only the mentioned columns will be returned.
-	 * @param readOpts.options.limit Int value that specifies the max number of records to return
-	 * @param readOpts.options.sort Specifies the name(s) of the column(s) to sort the result by (Sorting done in ascending order)
-	 *
-	 * @returns Resolves to the schedules
-	 */
-	public async readSchedules(
-		readOpts?: ScheduleReadFilterOptions
-	): Promise<Schedule[]> {
-		const endPoint = Schedule_Serv_EndPoints.Schedules
-		const query = encodeQuery({
-			...readOpts?.options,
-			filter: readOpts?.filter,
-		})
+	// *******************
+	// Schedule Operations
+	// *******************
 
-		const grid = await fetchVal<HGrid<Schedule>>(
-			this.makePath(`${endPoint}${query}`),
+	/**
+	 * Query all schedules.
+	 *
+	 * @param options Optional options for reading schedules.
+	 * @returns The HGrid result of the schedule read function.
+	 */
+	public async readAllSchedules(options?: ScheduleReadOptions) {
+		return fetchVal<HGrid<T>>(
+			`${this.#schedulesUrl}${encodeQuery({
+				...(options ?? {}),
+			})}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 			},
 			this.#serviceConfig.fetch
 		)
-
-		return grid.getRows()
 	}
 
 	/**
-	 * Creates the schedule object(s) as specified
+	 * Creates single or multiple schedules.
 	 *
-	 * @param rec Is/are the record(s) to be created
-	 *
-	 * @returns Resolves to the created schedules
+	 * @param schedules HDict | HGrid
+	 * @returns A grid containing the created schedules.
 	 */
-	public async createSchedules(rec: HGrid | HDict): Promise<Schedule[]> {
-		const path = Schedule_Serv_EndPoints.Schedules
-
-		const grid = await fetchVal<HGrid<Schedule>>(
-			this.makePath(path),
+	public async createSchedules(schedules: HDict | HGrid) {
+		return fetchVal<HGrid<T>>(
+			this.#schedulesUrl,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(rec.toJSON()),
 				method: 'POST',
-			},
-			this.#serviceConfig.fetch
-		)
-
-		return grid.getRows()
-	}
-
-	/**
-	 * Gets the schedule identified by its id
-	 *
-	 * @param id The schedule id
-	 *
-	 * @returns Resolves to a schedule
-	 */
-	public async readScheduleById(id: HRef | string): Promise<Schedule> {
-		const path = Schedule_Serv_EndPoints.Schedule.replace(
-			ID,
-			HRef.make(id).value
-		)
-
-		return fetchVal(
-			this.makePath(path),
-			{
-				...this.#serviceConfig.getDefaultOptions(),
+				body: JSON.stringify(dictsToGrid(schedules).toJSON()),
 			},
 			this.#serviceConfig.fetch
 		)
 	}
 
 	/**
-	 * Updates the schedule object
+	 * Read a schedule by its id.
 	 *
-	 * @param rec the updated schedule object
-	 *
-	 * @returns Resolves to resolving the updated schedule object
+	 * @param id string | HRef
+	 * @returns The schedule record.
 	 */
-	public async updateSchedule(rec: HDict): Promise<Schedule> {
-		const id = rec.get('id') as HRef
-		if (!id) {
-			throw new Error(ScheduleMessages.BadRequest)
-		}
-
-		const path = Schedule_Serv_EndPoints.Schedule.replace(ID, id.value)
-
-		return fetchVal(
-			this.makePath(path),
+	public async readScheduleById(id: string | HRef) {
+		return fetchVal<HDict<T>>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(rec.toJSON()),
+			}
+		)
+	}
+
+	/**
+	 * Updates a schedule.
+	 *
+	 * @param schedule Schedule | HDict
+	 * @returns The updated schedule record.
+	 */
+	public async updateSchedule(schedule: HDict) {
+		return fetchVal<HDict<T>>(
+			`${this.#schedulesUrl}/${schedule.id?.value ?? ''}`,
+			{
+				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',
+				body: JSON.stringify(schedule.toJSON()),
 			},
 			this.#serviceConfig.fetch
 		)
 	}
 
 	/**
-	 * Deletes a schedule object indetified by its id
+	 * Deletes a schedule by its id.
 	 *
-	 * @param id the of the schedule object to be deleted
-	 *
-	 * @return Resolves to the deleted schedule object
+	 * @param id string | HRef
+	 * @returns The deleted schedule.
 	 */
-	public async deleteSchedule(id: HRef | string): Promise<Schedule> {
-		const path = Schedule_Serv_EndPoints.Schedule.replace(
-			ID,
-			HRef.make(id).value
-		)
-
-		return fetchVal(
-			this.makePath(path),
+	public async deleteScheduleById(id: string | HRef) {
+		return fetchVal<T>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'DELETE',
@@ -178,279 +164,148 @@ export class ScheduleService {
 	}
 
 	/**
-	 * Gets all the events for the schedule object
+	 * Reads the calendars associated to a schedule.
 	 *
-	 * @param id the id of the schedule
-	 *
-	 * @returns Resolves to the events for the read schedule
+	 * @param id string | HRef
+	 * @returns HGrid<Calendar>
 	 */
-	public async readScheduleEvents(
-		id: HRef | string
-	): Promise<ScheduleEvent[]> {
-		const path = Schedule_Serv_EndPoints.Events.replace(
-			ID,
-			HRef.make(id).value
+	public async readScheduleCalendarsById(
+		id: string | HRef
+	): Promise<HGrid<CalendarEntry>> {
+		return fetchVal<HGrid<CalendarEntry>>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}/calendars`,
+			{
+				...this.#serviceConfig.getDefaultOptions(),
+			}
 		)
+	}
 
-		const grid = await fetchVal<HGrid<ScheduleEvent>>(
-			this.makePath(path),
+	/**
+	 * Reads all the schedulable points associated to a schedule.
+	 *
+	 * @param id string | HRef
+	 * @param options ScheduleReadOptions & { omit?: string[] }
+	 * @returns HGrid<SchedulablePoints>
+	 */
+	public async readSchedulablePoints(
+		id: string | HRef,
+		options?: ScheduleReadOptions
+	): Promise<HGrid<T>> {
+		return fetchVal<HGrid<T>>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}/points/${encodeQuery({
+				...(options ?? {}),
+			})}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 			},
 			this.#serviceConfig.fetch
 		)
-
-		return grid.getRows()
 	}
 
 	/**
-	 * Updates *all* the events for a schedule object. This will overwrite all the events to
-	 * when updating send all the events.
+	 * Adds or Removes schedulable points to/from a schedule.
 	 *
-	 * @param id the id of the schedule object
-	 * @param events the updated list of schedule events
-	 *
-	 * @returns Resolves to the events for the schedule
-	 */
-	public async updateScheduleEvents(
-		id: HRef | string,
-		events: HGrid
-	): Promise<ScheduleEvent[]> {
-		const path = Schedule_Serv_EndPoints.Events.replace(
-			ID,
-			HRef.make(id).value
-		)
-
-		const grid = await fetchVal<HGrid<ScheduleEvent>>(
-			this.makePath(path),
-			{
-				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(events.toJSON()),
-				method: 'PATCH',
-			},
-			this.#serviceConfig.fetch
-		)
-
-		return grid.getRows()
-	}
-
-	/**
-	 * Read all the points that are associated/scheduled with/by the specified schedule.
-	 *
-	 * @param id the id of the schedule
-	 *
-	 * @returns Resovles to all the points scheduled by the schedule
-	 */
-	public async readSchedulePoints(
-		id: HRef | string
-	): Promise<SchedulePoint[]> {
-		const path = Schedule_Serv_EndPoints.Points.replace(
-			ID,
-			HRef.make(id).value
-		)
-
-		const grid = await fetchVal<HGrid<SchedulePoint>>(
-			this.makePath(path),
-			{
-				...this.#serviceConfig.getDefaultOptions(),
-			},
-			this.#serviceConfig.fetch
-		)
-
-		return grid.getRows()
-	}
-
-	/**
-	 * Updates the schedule points (add/remove)
-	 *
-	 * @param id the id of the schedule
-	 * @param pointsToUpdate points to update
-	 * @param pointsToUpdate.add the array of point ids that have to be added
-	 * @param pointsToUpdate.remove the array of point ids that have to be removed
-	 *
-	 * @returns Resolves to a grid of all the updated points
+	 * @param id string | HRef
+	 * @param pointUpdates SchedulePointUpdate
+	 * @returns HGrid with all points that were added or removed.
 	 */
 	public async updateSchedulePoints(
-		id: HRef | string,
-		pointsToUpdate: SchedulePointUpdate
-	): Promise<SchedulePoint[]> {
-		if (
-			(!pointsToUpdate.add || pointsToUpdate.add.length < 1) &&
-			(!pointsToUpdate.remove || pointsToUpdate.remove.length < 1)
-		) {
-			return []
-		}
-
-		const path = Schedule_Serv_EndPoints.Points.replace(
-			ID,
-			HRef.make(id).value
-		)
-
-		const update = HDict.make()
-
-		if (pointsToUpdate.add) {
-			update.set('add', HList.make(pointsToUpdate.add))
-		}
-		if (pointsToUpdate.remove) {
-			update.set('remove', HList.make(pointsToUpdate.remove))
-		}
-
-		const grid = await fetchVal<HGrid<SchedulePoint>>(
-			this.makePath(path),
+		id: string | HRef,
+		pointUpdates: SchedulePointUpdate
+	) {
+		return fetchVal<HGrid<T>>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}/points/`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(update.toJSON()),
 				method: 'PATCH',
+				body: JSON.stringify(pointUpdates),
 			},
 			this.#serviceConfig.fetch
 		)
-
-		return grid.getRows()
 	}
 
-	/**
-	 * Gets all the calendars that the schedule subscribes to (has event from)
-	 *
-	 * @param scheduleId the schedule id
-	 *
-	 * @return Resolves to the calendar objects
-	 */
-	public async getScheduleCalendars(
-		scheduleId: HRef | string
-	): Promise<Calendar[]> {
-		const path = Schedule_Serv_EndPoints.ScheduleCalendars.replace(
-			ID,
-			HRef.make(scheduleId).value
-		)
+	// *******************
+	// Calendar Operations
+	// *******************
 
-		const grid = await fetchVal<HGrid<Calendar>>(
-			this.makePath(path),
+	/**
+	 * Query all calendars.
+	 *
+	 * @param options Optional options for reading calendars.
+	 * @returns The HGrid result of the calendar read function.
+	 */
+	public async readAllCalendars(options?: ScheduleReadOptions) {
+		return fetchVal<HGrid<T>>(
+			`${this.#calendarsUrl}${encodeQuery({
+				...(options ?? {}),
+			})}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 			},
 			this.#serviceConfig.fetch
 		)
-
-		return grid.getRows()
 	}
 
 	/**
-	 * Reads the calendars via a filter/options. If the filter is not provided, will get all the calendars
+	 * Creates single or multiple calendars.
 	 *
-	 * @param readOpts.filter is the filter string to be applied which fetching the calendars
-	 * @param readOpts.options are the read options
-	 * @param readOpts.options.columns Specifies the name(s) of the column(s) to get. If specified only the mentioned columns will be returned.
-	 * @param readOpts.options.limit Int value that specifies the max number of records to return
-	 * @param readOpts.options.sort Specifies the name(s) of the column(s) to sort the result by (Sorting done in ascending order)
-	 *
-	 * @returns A promise resolving calendar objects
+	 * @param calendars HDict | HGrid
+	 * @returns A grid containing the created calendar(s).
 	 */
-	public async readCalendars(
-		readOpts?: ScheduleReadFilterOptions
-	): Promise<Calendar[]> {
-		const endPoint = Schedule_Serv_EndPoints.Calendars
-		const query = encodeQuery({
-			...readOpts?.options,
-			filter: readOpts?.filter,
-		})
-
-		const grid = await fetchVal<HGrid<Calendar>>(
-			this.makePath(`${endPoint}${query}`),
-			{ ...this.#serviceConfig.getDefaultOptions() },
-			this.#serviceConfig.fetch
-		)
-
-		return grid.getRows()
-	}
-
-	/**
-	 * Creates new calendar object(s) as per the data supplied
-	 *
-	 * @param rec the dict/grid of records that are to be saved as new calendar object(s)
-	 *
-	 * @returns Resolves to created calendar objects
-	 */
-	public async createCalendars(rec: HDict | HGrid): Promise<Calendar[]> {
-		const path = Schedule_Serv_EndPoints.Calendars
-
-		const grid = await fetchVal<HGrid<Calendar>>(
-			this.makePath(path),
+	public async createCalendars(calendars: HDict | HGrid) {
+		return fetchVal<HGrid<T>>(
+			this.#schedulesUrl,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(rec.toJSON()),
 				method: 'POST',
-			},
-			this.#serviceConfig.fetch
-		)
-
-		return grid.getRows()
-	}
-
-	/**
-	 * Reads a particular calendar specified/identified by id
-	 *
-	 * @param calendarId the id of the calendar
-	 *
-	 * @returns Resolves to a calendar object
-	 */
-	public async readCalendarById(
-		calendarId: HRef | string
-	): Promise<Calendar> {
-		const path = Schedule_Serv_EndPoints.Calendar.replace(
-			ID,
-			HRef.make(calendarId).value
-		)
-
-		return fetchVal(
-			this.makePath(path),
-			{
-				...this.#serviceConfig.getDefaultOptions(),
+				body: JSON.stringify(dictsToGrid(calendars).toJSON()),
 			},
 			this.#serviceConfig.fetch
 		)
 	}
 
 	/**
-	 * Updates the calendar object with the current/specified object
+	 * Read a calendar by its id.
 	 *
-	 * @param calendar the calendar object
-	 *
-	 * @returns Resolves with the updated calendar object
+	 * @param id string | HRef
+	 * @returns The calendar record.
 	 */
-	public async updateCalendar(calendar: HDict): Promise<Calendar> {
-		const id = calendar.get('id') as HRef
-		if (!id) {
-			throw new Error(ScheduleMessages.BadRequest)
-		}
-
-		const path = Schedule_Serv_EndPoints.Calendar.replace(ID, id.value)
-
-		return fetchVal(
-			this.makePath(path),
+	public async readCalendarById(id: string | HRef) {
+		return fetchVal<HDict<T>>(
+			`${this.#calendarsUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-				body: JSON.stringify(calendar.toJSON()),
+			}
+		)
+	}
+
+	/**
+	 * Updates a calendar.
+	 *
+	 * @param schedule Calendar | HDict
+	 * @returns The updated calendar record.
+	 */
+	public async updateCalendar(calendar: HDict) {
+		return fetchVal<HDict<T>>(
+			`${this.#calendarsUrl}/${calendar.id?.value ?? ''}`,
+			{
+				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',
+				body: JSON.stringify(calendar.toJSON()),
 			},
 			this.#serviceConfig.fetch
 		)
 	}
 
 	/**
-	 * Deletes a calendar object identified by the id
+	 * Deletes a calendar by its id.
 	 *
-	 * @param calendarId the calendar id
-	 *
-	 * @returns Resolves to the deleted calendar object
+	 * @param id string | HRef
+	 * @returns The deleted calendar.
 	 */
-	public async deleteCalendar(calendarId: HRef | string): Promise<Calendar> {
-		const path = Schedule_Serv_EndPoints.Calendar.replace(
-			ID,
-			HRef.make(calendarId).value
-		)
-
-		return fetchVal(
-			this.makePath(path),
+	public async deleteCalendarById(id: string | HRef) {
+		return fetchVal<T>(
+			`${this.#calendarsUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'DELETE',
@@ -460,32 +315,19 @@ export class ScheduleService {
 	}
 
 	/**
-	 * Reads all the schedules that the said calendar is subscribed by
+	 * Reads the schedules associated to a calendar.
 	 *
-	 * @param calendarId the calendar id
-	 *
-	 * @returns Resolves to the calendar objects
+	 * @param id string | HRef
+	 * @returns HGrid<Schedule>
 	 */
-	public async getCalendarSchedules(
-		calendarId: HRef | string
-	): Promise<Schedule[]> {
-		const path = Schedule_Serv_EndPoints.CalendarSchedules.replace(
-			ID,
-			HRef.make(calendarId).value
-		)
-
-		const grid = await fetchVal<HGrid<Schedule>>(
-			this.makePath(path),
+	public async readCalendarSchedulesById(
+		id: string | HRef
+	): Promise<HGrid<CalendarEntry>> {
+		return fetchVal<HGrid<CalendarEntry>>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}/schedules`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
-			},
-			this.#serviceConfig.fetch
+			}
 		)
-
-		return grid.getRows()
-	}
-
-	private makePath(path: string): string {
-		return this.#serviceConfig.getHaystackServiceUrl(path)
 	}
 }

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -9,42 +9,13 @@ import {
 	Schedule,
 	Calendar,
 	CalendarEntry,
+	ScheduleReadOptions,
 } from './types'
 import { fetchVal } from '../fetchVal'
 import { ClientServiceConfig } from '../ClientServiceConfig'
 import { ScheduleEvent, SchedulePoint } from './types'
 import { encodeQuery } from '../../util/http'
 import { dictsToGrid } from '../../util/hval'
-
-/**
- * Options for reading Schedules and Calendars.
- */
-export type ScheduleReadOptions = {
-	/**
-	 * If defined, Gets the functions filtered by a Haystack filter
-	 */
-	filter?: string
-
-	/**
-	 * If defined, specifies the name of the tag/prop by which the returned function records are sorted in ascending order.
-	 */
-	sort?: string[]
-
-	/**
-	 * If defined, specifies the max number of function records that will be returned by the read
-	 */
-	limit?: number
-
-	/**
-	 * If defined, limit the number of columns sent back in the response.
-	 */
-	columns?: string[]
-
-	/**
-	 * Omit the specified columns from the response.
-	 */
-	omit?: string[]
-}
 
 export class ScheduleService {
 	/**

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -2,13 +2,14 @@
  * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
-import { HGrid, HRef } from 'haystack-core'
+import { HDict, HGrid, HRef } from 'haystack-core'
 import {
 	SchedulePointUpdate,
 	Schedule,
 	Calendar,
 	ScheduleReadOptions,
 	SchedulablePoint,
+	ScheduleServiceEndpoints,
 } from './types'
 import { fetchVal } from '../fetchVal'
 import { ClientServiceConfig } from '../ClientServiceConfig'
@@ -38,8 +39,13 @@ export class ScheduleService {
 	 */
 	public constructor(serviceConfig: ClientServiceConfig) {
 		this.#serviceConfig = serviceConfig
-		this.#calendarsUrl = serviceConfig.getHaystackServiceUrl('calendars')
-		this.#schedulesUrl = serviceConfig.getHaystackServiceUrl('schedules')
+
+		this.#calendarsUrl = serviceConfig.getHaystackServiceUrl(
+			ScheduleServiceEndpoints.Calendars
+		)
+		this.#schedulesUrl = serviceConfig.getHaystackServiceUrl(
+			ScheduleServiceEndpoints.Schedules
+		)
 	}
 
 	// *******************
@@ -67,10 +73,10 @@ export class ScheduleService {
 	/**
 	 * Creates single or multiple schedules.
 	 *
-	 * @param schedules Schedule | HGrid of Schedule
+	 * @param schedules Schedule | HDict | HGrid
 	 * @returns A grid containing the created schedules.
 	 */
-	public async createSchedules(schedules: Schedule | HGrid<Schedule>) {
+	public async createSchedules(schedules: Schedule | HDict | HGrid) {
 		return fetchVal<HGrid<Schedule>>(
 			this.#schedulesUrl,
 			{
@@ -151,7 +157,7 @@ export class ScheduleService {
 	 * Reads all the schedulable points associated to a schedule.
 	 *
 	 * @param id string | HRef
-	 * @param options ScheduleReadOptions & { omit?: string[] }
+	 * @param options ScheduleReadOptions
 	 * @returns HGrid of SchedulablePoints
 	 */
 	public async readSchedulablePoints(
@@ -159,7 +165,7 @@ export class ScheduleService {
 		options?: ScheduleReadOptions
 	) {
 		return fetchVal<HGrid<SchedulablePoint>>(
-			`${this.#schedulesUrl}/${HRef.make(id).value}/points/${encodeQuery({
+			`${this.#schedulesUrl}/${HRef.make(id).value}/points${encodeQuery({
 				...(options ?? {}),
 			})}`,
 			{
@@ -181,7 +187,7 @@ export class ScheduleService {
 		pointUpdates: SchedulePointUpdate
 	) {
 		return fetchVal<HGrid<SchedulablePoint>>(
-			`${this.#schedulesUrl}/${HRef.make(id).value}/points/`,
+			`${this.#schedulesUrl}/${HRef.make(id).value}/points`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',
@@ -216,10 +222,10 @@ export class ScheduleService {
 	/**
 	 * Creates single or multiple calendars.
 	 *
-	 * @param calendars Calendar | HGrid of Calendar
+	 * @param calendars Calendar | HDict | HGrid
 	 * @returns A grid containing the created calendar(s).
 	 */
-	public async createCalendars(calendars: Calendar | HGrid<Calendar>) {
+	public async createCalendars(calendars: Calendar | HDict | HGrid) {
 		return fetchVal<HGrid<Calendar>>(
 			this.#schedulesUrl,
 			{
@@ -254,7 +260,7 @@ export class ScheduleService {
 	 */
 	public async updateCalendar(calendar: Calendar) {
 		return fetchVal<Calendar>(
-			`${this.#calendarsUrl}/${calendar.id?.value ?? ''}`,
+			`${this.#calendarsUrl}/${calendar.id?.value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',
@@ -289,7 +295,7 @@ export class ScheduleService {
 	 */
 	public async readCalendarSchedulesById(id: string | HRef) {
 		return fetchVal<HGrid<Schedule>>(
-			`${this.#schedulesUrl}/${HRef.make(id).value}/schedules`,
+			`${this.#calendarsUrl}/${HRef.make(id).value}/schedules`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 			}

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -76,7 +76,7 @@ export class ScheduleService {
 	 * @param schedules Schedule | HDict | HGrid
 	 * @returns A grid containing the created schedules.
 	 */
-	public async createSchedules(schedules: Schedule | HDict | HGrid) {
+	public async createSchedules(schedules: Schedule | HGrid<Schedule>) {
 		return fetchVal<HGrid<Schedule>>(
 			this.#schedulesUrl,
 			{
@@ -106,12 +106,13 @@ export class ScheduleService {
 	/**
 	 * Updates a schedule.
 	 *
+	 * @param id The id of the record to update
 	 * @param schedule Schedule | HDict
 	 * @returns The updated schedule record.
 	 */
-	public async updateSchedule(schedule: Schedule) {
+	public async updateSchedule(id: string | HRef, schedule: HDict) {
 		return fetchVal<Schedule>(
-			`${this.#schedulesUrl}/${schedule.id?.value ?? ''}`,
+			`${this.#schedulesUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',
@@ -222,10 +223,10 @@ export class ScheduleService {
 	/**
 	 * Creates single or multiple calendars.
 	 *
-	 * @param calendars Calendar | HDict | HGrid
+	 * @param calendars Calendar | HGrid
 	 * @returns A grid containing the created calendar(s).
 	 */
-	public async createCalendars(calendars: Calendar | HDict | HGrid) {
+	public async createCalendars(calendars: Calendar | HGrid<Calendar>) {
 		return fetchVal<HGrid<Calendar>>(
 			this.#calendarsUrl,
 			{
@@ -258,9 +259,9 @@ export class ScheduleService {
 	 * @param schedule Calendar
 	 * @returns The updated calendar record.
 	 */
-	public async updateCalendar(calendar: Calendar) {
+	public async updateCalendar(id: string | HRef, calendar: HDict) {
 		return fetchVal<Calendar>(
-			`${this.#calendarsUrl}/${calendar.id?.value}`,
+			`${this.#calendarsUrl}/${HRef.make(id).value}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 				method: 'PATCH',

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -11,7 +11,7 @@ import {
 	HNum,
 	HRef,
 	HStr,
-	HVal,
+	OptionalHVal,
 	Kind,
 } from 'haystack-core'
 
@@ -98,8 +98,8 @@ export interface SchedulablePoint extends HDict {
  * Interface for adding and/or removing schedulable points
  */
 export interface SchedulePointUpdate {
-	add?: HRef[]
-	remove?: HRef[]
+	add?: HList<HRef>
+	remove?: HList<HRef>
 }
 
 /**
@@ -117,14 +117,19 @@ export interface Schedule extends HDict {
 	dis: HStr
 
 	/**
-	 * Is the date-time when the schedule was last modified
+	 * Is the date-time when the schedule was last modified.
 	 */
 	mod?: HDateTime
 
 	/**
+	 * The required timezone of the schedule.
+	 */
+	tz: HStr
+
+	/**
 	 * Is the current value of the schedule.
 	 */
-	curVal?: HVal
+	curVal?: OptionalHVal
 
 	/**
 	 * Is the schedule kind (bool, number, str).
@@ -139,12 +144,12 @@ export interface Schedule extends HDict {
 	/**
 	 * Specifies the default value of the schedule (if any).
 	 */
-	defaultVal?: HVal
+	defaultVal?: OptionalHVal
 
 	/**
 	 * Is the next value of the schedule (whenever it changes).
 	 */
-	nextVal?: HVal
+	nextVal?: OptionalHVal
 
 	/**
 	 * Specifies the date-time when the value of schedule will update next.
@@ -159,48 +164,48 @@ export interface Schedule extends HDict {
 	/**
 	 * One week of schedules per day.
 	 */
-	weeklySchedule?: WeekDaySchedule[]
+	weeklySchedule?: HList<WeekDaySchedule>
 
 	/**
 	 * The scheduled exceptions.
 	 */
-	exceptionSchedule?: SpecialEvent[]
+	exceptionSchedule?: ExceptionSchedule
 }
 
 /**
  * Defines the day of week and schedule for that day.
  */
-export interface WeekDaySchedule {
+export interface WeekDaySchedule extends HDict {
 	dayOfWeek: HNum
-	dailySchedule: DailySchedule[]
+	dailySchedule: HList<DailySchedule>
 }
 
 /**
  * A List of Schedules Exceptions.
  */
-export type ExceptionSchedule = SpecialEvent[]
+export type ExceptionSchedule = HList<SpecialEvent>
 
 /**
  * Defines data for a special event.
  */
-export interface SpecialEvent {
+export interface SpecialEvent extends HDict {
 	calendarEntry?: CalendarEntry
 	calendarRef?: HRef
 	priority: number
-	dailySchedule: DailySchedule[]
+	dailySchedule: HList<DailySchedule>
 }
 
 /**
  * Defines the schedule for a day.
  */
-export interface DailySchedule {
+export interface DailySchedule extends HDict {
 	bacnetTime: {
-		hour: number
-		minute: number
-		second: number
-		hundredths: number
+		hour?: number
+		minute?: number
+		second?: number
+		hundredths?: number
 	}
-	scheduledVal: HVal
+	scheduledVal: OptionalHVal
 }
 
 /**
@@ -250,10 +255,10 @@ export type CalendarEntry =
  * A Date for a Calendar.
  */
 export interface CalendarDate {
-	year: number
-	month: number
-	dayOfMonth: number
-	dayOfWeek: number
+	year?: number
+	month?: number
+	dayOfMonth?: number
+	dayOfWeek?: number
 }
 
 /**
@@ -268,6 +273,7 @@ export interface CalendarRange {
  * Define the week and day of a Calendar.
  */
 export interface CalendarWeekNDay {
-	nthWeek: number
-	dayOfWeek: number
+	weekOfMonth?: number
+	month?: number
+	dayOfWeek?: number
 }

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, J2 Innovations. All Rights Reserved
+ * Copyright (c) 2020-2023, J2 Innovations. All Rights Reserved
  */
 
 import {
@@ -13,14 +13,42 @@ import {
 	HStr,
 	HTime,
 	HVal,
+	Kind,
 } from 'haystack-core'
 
-export interface ScheduleReadOptions {
-	columns?: string[]
-	limit?: number
+/**
+ * Options for reading Schedules and Calendars.
+ */
+export type ScheduleReadOptions = {
+	/**
+	 * If defined, Gets the functions filtered by a Haystack filter
+	 */
+	filter?: string
+
+	/**
+	 * If defined, specifies the name of the tag/prop by which the returned function records are sorted in ascending order.
+	 */
 	sort?: string[]
+
+	/**
+	 * If defined, specifies the max number of function records that will be returned by the read
+	 */
+	limit?: number
+
+	/**
+	 * If defined, limit the number of columns sent back in the response.
+	 */
+	columns?: string[]
+
+	/**
+	 * Omit the specified columns from the response.
+	 */
+	omit?: string[]
 }
 
+/**
+ * Interface for adding and/or removing schedulable points
+ */
 export interface SchedulePointUpdate {
 	add?: HRef[]
 	remove?: HRef[]
@@ -34,13 +62,13 @@ export interface ScheduleRange extends HDict {
 	 * Specifies the date when the schedule starts to be active. If not specified, is/was
 	 * always active
 	 */
-	start?: HDate
+	lowBound?: HDate
 
 	/**
 	 * Specifies the date when the schedule ceases to be active. IF not specifies will
 	 * start active forever
 	 */
-	end?: HDate
+	upBound?: HDate
 }
 
 /**
@@ -152,6 +180,38 @@ export interface SchedulePeriod extends HDict {
 }
 
 /**
+ * A list of daily schedules for a week.
+ */
+export type WeeklySchedule = WeekDaySchedule[]
+
+/**
+ * Defines the day of week and schedule for that day.
+ */
+export interface WeekDaySchedule extends HDict {
+	dayOfWeek: HNum,
+	dailySchedule: DailySchedule
+}
+
+/**
+ * Defines the schedule for a day.
+ */
+export interface DailySchedule extends HDict {
+	bacnetTime: {
+		hour: HNum
+		minute: HNum
+		second: HNum
+		hundredths: HNum
+	}
+	scheduledVal: HVal
+}
+
+export type ExceptionSchedules = ExeceptionSchedule[]
+
+export interface ExeceptionSchedule extends HDict {
+
+}
+
+/**
  * Is the calendar entry object
  */
 export interface CalendarEntry extends HDict {
@@ -234,18 +294,13 @@ export interface ScheduleEvent extends HDict {
 }
 
 /**
- * Is the Schedule object
+ * Schedule object
  */
 export interface Schedule extends HDict {
 	/**
 	 * Is the id of the scehdule object
 	 */
 	id: HRef
-
-	/**
-	 * Is the date/time value when the schedule was modified last
-	 */
-	mod: HDateTime
 
 	/**
 	 * Specifies the name of the schedule
@@ -255,43 +310,48 @@ export interface Schedule extends HDict {
 	/**
 	 * Is the schedule kind (bool, number, str)
 	 */
-	kind: HStr
+	kind: Kind
+
+	/**
+	 * Is the range of dates (if any) that the schedule is active
+	 */
+	effectivePeriod: ScheduleRange
 
 	/**
 	 * Is the current value of the schedule
 	 */
-	curVal: HVal
-
-	/**
-	 * Is the next value of the schedule (whenever it changes)
-	 */
-	nextVal: HVal
-
-	/**
-	 * Specifies the date-time when the value of schedule will update next
-	 */
-	nextChange: HDateTime
+	curVal?: HVal
 
 	/**
 	 * Is the list of calendar(s) the schedule subscribes to
 	 */
-	calendars?: HList<HRef>
-
-	/**
-	 * Specifies the list of enumerated values that the schedule value can have. Only applicable
-	 * when the schedule is of the type string
-	 */
-	enum?: HList<HStr>
+	calendarRefs?: HList<HRef>
 
 	/**
 	 * Specifies the default value of the schedule (if any)
 	 */
 	defaultVal?: HVal
+	/**
+	 * Is the next value of the schedule (whenever it changes)
+	 */
+	nextVal?: HVal
 
 	/**
-	 * Is the range of dates (if any) that the schedule is active
+	 * Specifies the date-time when the value of schedule will update next
 	 */
-	range?: ScheduleRange
+	nextTime?: HDateTime
+
+	/**
+	 * Is the date/time value when the schedule was modified last
+	 */
+	mod?: HDateTime
+
+	/**
+	 * One week of schedules per day
+	 */
+	weeklySchedule?: WeeklySchedule
+
+	exceptionSchedule?: 
 }
 
 /**

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -3,15 +3,14 @@
  */
 
 import {
-	HBool,
 	HDate,
 	HDateTime,
 	HDict,
 	HList,
+	HMarker,
 	HNum,
 	HRef,
 	HStr,
-	HTime,
 	HVal,
 	Kind,
 } from 'haystack-core'
@@ -47,6 +46,47 @@ export type ScheduleReadOptions = {
 }
 
 /**
+ * Object defining the Schedulable point
+ */
+export interface SchedulablePoint extends HDict {
+	/**
+	 * id of the point
+	 */
+	id: HRef
+
+	/**
+	 * Name of the point.
+	 */
+	dis: HStr
+
+	/**
+	 * Is the schedule kind (bool, number, str).
+	 */
+	kind: Kind
+
+	/**
+	 * Marker tag describing the object as a point
+	 */
+	point: HMarker
+
+	/**
+	 * Is the date-time when the point was last modified
+	 */
+	mod?: HDateTime
+
+	/**
+	 * Is the number specifying to what priority on the point should the
+	 * schedule be writing on. Range 1-15
+	 */
+	schedulable: number
+
+	/**
+	 * Is the schedule that is writing to the point
+	 */
+	scheduleRef: HRef
+}
+
+/**
  * Interface for adding and/or removing schedulable points
  */
 export interface SchedulePointUpdate {
@@ -55,357 +95,171 @@ export interface SchedulePointUpdate {
 }
 
 /**
- * The schedule range object
+ * Schedule object.
  */
-export interface ScheduleRange extends HDict {
+export interface Schedule extends HDict {
 	/**
-	 * Specifies the date when the schedule starts to be active. If not specified, is/was
-	 * always active
+	 * id of the schedule object.
 	 */
-	lowBound?: HDate
+	id?: HRef
 
 	/**
-	 * Specifies the date when the schedule ceases to be active. IF not specifies will
-	 * start active forever
+	 * Specifies the name of the schedule.
 	 */
-	upBound?: HDate
+	dis: HStr
+
+	/**
+	 * Is the date-time when the schedule was last modified
+	 */
+	mod?: HDateTime
+
+	/**
+	 * Is the current value of the schedule.
+	 */
+	curVal?: HVal
+
+	/**
+	 * Is the schedule kind (bool, number, str).
+	 */
+	kind: Kind
+
+	/**
+	 * Is the list of calendar(s) the schedule subscribes to.
+	 */
+	calendarRefs?: HList<HRef>
+
+	/**
+	 * Specifies the default value of the schedule (if any).
+	 */
+	defaultVal?: HVal
+
+	/**
+	 * Is the next value of the schedule (whenever it changes).
+	 */
+	nextVal: HVal
+
+	/**
+	 * Specifies the date-time when the value of schedule will update next.
+	 */
+	nextTime: HDateTime
+
+	/**
+	 * Is the range of dates (if any) that the schedule is active.
+	 */
+	effectivePeriod: CalendarRange
+
+	/**
+	 * One week of schedules per day.
+	 */
+	weeklySchedule?: WeekDaySchedule[]
+
+	/**
+	 * The scheduled exceptions.
+	 */
+	exceptionSchedule?: SpecialEvent[]
 }
-
-/**
- * Specifies the pattern for a date end point for an event.
- */
-export interface DatePatternEndPoint extends HDict {
-	/**
-	 * Specifies the year of the event. If not set, it occur any/every year
-	 */
-	year?: HNum
-
-	/**
-	 * Specifies the month of the event. If not specified, it occurs every/any month.
-	 * Range [1..12] => [Jan..Dec]
-	 */
-	month?: HNum
-
-	/**
-	 * Specifies the date of the event occurance in a month
-	 * Range [1..31]
-	 */
-	date: HNum
-}
-
-/**
- * The schedule event/calendar entry date-rule
- */
-export interface SchedulePeriodDateRuleType extends HDict {
-	/**
-	 * Specifies the nth week of a month with some special cases.
-	 * - **positive(> 0)** values specify the nth week from the start of the month with the max value of 5
-	 * - **negative(< 0)** values specify the nth week from the end of the month (eg: -2 = 2nd last week)
-	 * - the value of **0** means any/all the weeks
-	 */
-	nthWeek: HNum
-
-	/**
-	 * Specifies the nth day on the week with special cases
-	 * - values **1..7** state the days **sun..sat**
-	 * - value of **0** means **all/any** day of the week
-	 */
-	nthDay: HNum
-
-	/**
-	 * Specifies the nth month in a year for the event, with some special cases.
-	 * - values **1..12** represent normal months, **jan..dec**
-	 * - value **13** means all **odd** months starting with jan
-	 * - value of **14** means all **even** months starting with feb
-	 * - and the value of **0** mean any/all months
-	 */
-	nthMonth: HNum
-}
-
-/**
- * Specifies the day of the weeks with 1 = sun and 7 = sat
- */
-export type SchedulePeriodWeekdays = HList<HNum>
-
-/**
- * Specifies the event/entry date range pattern
- */
-export interface SchedulePeriodDateRangePatternType extends HDict {
-	/**
-	 * Specifies the start of the event/entry
-	 */
-	start: DatePatternEndPoint
-
-	/**
-	 * Specifies the end of the event/entry (if any)
-	 */
-	end?: DatePatternEndPoint
-}
-
-/**
- * Specifies the date-range of a schedule/calendar event/entry
- */
-export interface SchedulePeriodDateRangeType extends HDict {
-	/**
-	 * Is the start date of the event/entry
-	 */
-	start: HDate
-
-	/**
-	 * Is the end date of the event/entry
-	 */
-	end: HDate
-}
-
-/**
- * Specifies the schedule/calendar event/entry period
- */
-export interface SchedulePeriod extends HDict {
-	/**
-	 * Indetifies the type of period value for the event/entry. The value of this
-	 * can be one of [date, dateRange, datePattern, dateRangePattern, dateRule, weekdays]
-	 */
-	type: HStr
-
-	/**
-	 * Specifies the value of the event/entry period
-	 */
-	val:
-		| HDate /* when type = date */
-		| SchedulePeriodDateRangeType /* when type = dateRange */
-		| SchedulePeriodDateRangePatternType /* when type = dateRangePattern */
-		| DatePatternEndPoint /* when type = datePattern */
-		| SchedulePeriodDateRuleType /* when type = dateRule */
-		| SchedulePeriodWeekdays /* when type = weekdays */
-}
-
-/**
- * A list of daily schedules for a week.
- */
-export type WeeklySchedule = WeekDaySchedule[]
 
 /**
  * Defines the day of week and schedule for that day.
  */
-export interface WeekDaySchedule extends HDict {
-	dayOfWeek: HNum,
-	dailySchedule: DailySchedule
+export interface WeekDaySchedule {
+	dayOfWeek: HNum
+	dailySchedule: DailySchedule[]
+}
+
+/**
+ * A List of Schedules Exceptions.
+ */
+export type ExceptionSchedule = SpecialEvent[]
+
+/**
+ * Defines data for a special event.
+ */
+export interface SpecialEvent {
+	calendarEntry?: CalendarEntry
+	calendarRef?: HRef
+	priority: number
+	dailySchedule: DailySchedule[]
 }
 
 /**
  * Defines the schedule for a day.
  */
-export interface DailySchedule extends HDict {
+export interface DailySchedule {
 	bacnetTime: {
-		hour: HNum
-		minute: HNum
-		second: HNum
-		hundredths: HNum
+		hour: number
+		minute: number
+		second: number
+		hundredths: number
 	}
 	scheduledVal: HVal
 }
 
-export type ExceptionSchedules = ExeceptionSchedule[]
-
-export interface ExeceptionSchedule extends HDict {
-
-}
-
 /**
- * Is the calendar entry object
+ * The Calendar object.
  */
-export interface CalendarEntry extends HDict {
+export interface Calendar extends HDict {
 	/**
-	 * Specifies the name/value for the calendar entry
+	 * Is the id of the calendar object.
 	 */
-	val?: HStr
+	id?: HRef
 
 	/**
-	 * Is the id of the calendar to which this entry belongs (in case of extended calendars)
-	 */
-	calendar?: HRef
-
-	/**
-	 * Specifies the period of the entry
-	 */
-	period: SchedulePeriod
-}
-
-/**
- * Is the schedule event
- */
-export interface ScheduleEvent extends HDict {
-	/**
-	 * Is the display name/label for the event
+	 * Specifies the name of the calendar.
 	 */
 	dis?: HStr
 
 	/**
-	 * Specifies the event type. Can be one on ['exception', 'weekly']
-	 */
-	type: HStr
-
-	/**
-	 * Specifies the start time of the event in a day
-	 */
-	start: HTime
-
-	/**
-	 * Specifies the end time of the event in a day
-	 */
-	end: HTime
-
-	/**
-	 * Specifies the value of the calendar (if this event is being delievered from a calendar and if there is a calendar value)
-	 */
-	calValue: HStr
-
-	/**
-	 * Is the value of the event. Is the value which will be applied to all the points that are being
-	 * scheduled via this schedule during the times when this event is active
-	 */
-	val: HStr | HBool | HNum
-
-	/**
-	 * Specifies the event priority. This helps determine event precidence when various/multiple events
-	 * compete for the same time/date slot. Value range is 0..16. The higher the value, lower the priority.
-	 */
-	priority: HNum
-
-	/**
-	 * The status of the event (if any)
-	 */
-	status?: HStr
-
-	/**
-	 * Is the calendar id for the event, if the event is provided by a calendar
-	 */
-	calendar?: HRef
-
-	/**
-	 * Specifies the error (if any) associated with the event
-	 */
-	err?: HStr
-
-	/**
-	 * Specifies the period of the event. This determines the date value of the event in a year (or over multiple years)
-	 */
-	period?: SchedulePeriod
-}
-
-/**
- * Schedule object
- */
-export interface Schedule extends HDict {
-	/**
-	 * Is the id of the scehdule object
-	 */
-	id: HRef
-
-	/**
-	 * Specifies the name of the schedule
-	 */
-	dis: HStr
-
-	/**
-	 * Is the schedule kind (bool, number, str)
-	 */
-	kind: Kind
-
-	/**
-	 * Is the range of dates (if any) that the schedule is active
-	 */
-	effectivePeriod: ScheduleRange
-
-	/**
-	 * Is the current value of the schedule
-	 */
-	curVal?: HVal
-
-	/**
-	 * Is the list of calendar(s) the schedule subscribes to
-	 */
-	calendarRefs?: HList<HRef>
-
-	/**
-	 * Specifies the default value of the schedule (if any)
-	 */
-	defaultVal?: HVal
-	/**
-	 * Is the next value of the schedule (whenever it changes)
-	 */
-	nextVal?: HVal
-
-	/**
-	 * Specifies the date-time when the value of schedule will update next
-	 */
-	nextTime?: HDateTime
-
-	/**
-	 * Is the date/time value when the schedule was modified last
+	 * Is the date-time when the calendar was last modified
 	 */
 	mod?: HDateTime
 
 	/**
-	 * One week of schedules per day
+	 * The Marker tag describing as calendar.
 	 */
-	weeklySchedule?: WeeklySchedule
+	calender: HMarker
 
-	exceptionSchedule?: 
+	/**
+	 * The Ref of the calendar.
+	 */
+	calendarRef?: HRef
+
+	/**
+	 * The calendar entries
+	 */
+	entries?: CalendarEntry[]
 }
 
 /**
- * The Calendar object
+ * A Calendar Entry.
  */
-export interface Calendar extends HDict {
-	/**
-	 * Specifies the id of the calendar
-	 */
-	id: HRef
+export type CalendarEntry =
+	| ({ entryType: 'Date' } & CalendarDate)
+	| ({ entryType: 'Range' } & CalendarRange)
+	| ({ entryType: 'WeekNDay' } & CalendarWeekNDay)
 
-	/**
-	 * Is the date-time when the calendar was last modified
-	 */
-	mod: HDateTime
-
-	/**
-	 * Specifies the display name/label of the calendar
-	 */
-	dis: HStr
-
-	/**
-	 * Specifies the value of the calendar object (if any)
-	 */
-	val?: HStr
-
-	/**
-	 * Specifies the parent calendar object (if any)
-	 */
-	extends?: HRef
-
-	/**
-	 * Specifies the list of all the entries that the calendar is active
-	 */
-	entries: HList<CalendarEntry>
+/**
+ * A Date for a Calendar.
+ */
+export interface CalendarDate {
+	year: number
+	month: number
+	dayOfMonth: number
+	dayOfWeek: number
 }
 
 /**
- * Object defining the schedule point
+ * The Date range of a Calendar.
  */
-export interface SchedulePoint extends HDict {
-	/**
-	 * Is the id of the point
-	 */
-	id: HRef
+export interface CalendarRange {
+	lowBound: HDate
+	upBound: HDate
+}
 
-	/**
-	 * Is the number specifying to what priority on the point should the
-	 * schedule be writing on. Range 1-15
-	 */
-	schedulable: HNum
-
-	/**
-	 * Is the schedule that is writing to the point
-	 */
-	scheduleRef: HRef
+/**
+ * Define the week and day of a Calendar.
+ */
+export interface CalendarWeekNDay {
+	nthWeek: number
+	dayOfWeek: number
 }

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, J2 Innovations. All Rights Reserved
+ * Copyright (c) 2020, J2 Innovations. All Rights Reserved
  */
 
 import {
@@ -14,6 +14,14 @@ import {
 	HVal,
 	Kind,
 } from 'haystack-core'
+
+/**
+ * The entry endpoints for the Schedule Service
+ */
+export enum ScheduleServiceEndpoints {
+	Schedules = 'schedules',
+	Calendars = 'calendars',
+}
 
 /**
  * Options for reading Schedules and Calendars.
@@ -136,12 +144,12 @@ export interface Schedule extends HDict {
 	/**
 	 * Is the next value of the schedule (whenever it changes).
 	 */
-	nextVal: HVal
+	nextVal?: HVal
 
 	/**
 	 * Specifies the date-time when the value of schedule will update next.
 	 */
-	nextTime: HDateTime
+	nextTime?: HDateTime
 
 	/**
 	 * Is the range of dates (if any) that the schedule is active.
@@ -252,8 +260,8 @@ export interface CalendarDate {
  * The Date range of a Calendar.
  */
 export interface CalendarRange {
-	lowBound: HDate
-	upBound: HDate
+	lowBound?: HDate
+	upBound?: HDate
 }
 
 /**


### PR DESCRIPTION
This PR adds the following functionality:
- Updates Schedule Service to use newly define REST API endpoints.
- Updates Type Definitions utilized in the schedule service.
- Updates tests with the updated Record mocks and endpoints.

@hecsalazarf Please take extra care when reviewing the Type schemas. I attempted to extract them from the OpenAPI docs as best I could and it's important for implementation that these match as best as possible.

---

![Screenshot 2023-05-10 at 11 02 20 AM](https://github.com/j2inn/haystack-nclient/assets/690624/4609b904-ed30-4e9d-9080-fd71c18f1cfa)
