### PR TITLE
STK-1376: Schedule Event APIs

### DIFF
--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -108,13 +108,13 @@ const mockScheduleEvents = (): HDict => {
 	return new HDict({
 		events: HList.make(
 			HDict.make({
-				start: HDateTime.make('2024-02-12T00:00:00.000Z'),
-				end: HDateTime.make('2024-02-13T00:00:00.000Z'),
+				startTime: HDateTime.make('2024-02-12T00:00:00.000Z'),
+				endTime: HDateTime.make('2024-02-13T00:00:00.000Z'),
 				val: true,
 			}),
 			HDict.make({
-				start: HDateTime.make('2024-02-14T00:00:00.000Z'),
-				end: HDateTime.make('2024-02-15T00:00:00.000Z'),
+				startTime: HDateTime.make('2024-02-14T00:00:00.000Z'),
+				endTime: HDateTime.make('2024-02-15T00:00:00.000Z'),
 				val: false,
 			})
 		),
@@ -776,11 +776,9 @@ describe('ScheduleService', () => {
 		it('return events for schedule within range', async () => {
 			const start = '2024-02-12T00:00:00.000Z'
 			const end = '2024-02-13T00:00:00.000Z'
+			const options = { start, end }
 
-			await service.readScheduleEvents(HRef.make('123'), {
-				start,
-				end,
-			})
+			await service.readScheduleEvents(HRef.make('123'), options)
 
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(
@@ -793,10 +791,9 @@ describe('ScheduleService', () => {
 
 		it('return next event for schedule from start date', async () => {
 			const start = '2024-02-12T00:00:00.000Z'
+			const options = { start }
 
-			await service.readScheduleEvents(HRef.make('123'), {
-				start,
-			})
+			await service.readScheduleEvents(HRef.make('123'), options)
 
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(

--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -108,26 +108,14 @@ const mockScheduleEvents = (): HDict => {
 	return new HDict({
 		events: HList.make(
 			HDict.make({
-				start: HDateTime.make(new Date('1988-02-23').toISOString()),
-				end: HDateTime.make(new Date('1988-02-24').toISOString()),
+				start: HDateTime.make('2024-02-12T00:00:00.000Z'),
+				end: HDateTime.make('2024-02-13T00:00:00.000Z'),
 				val: true,
 			}),
 			HDict.make({
-				start: HDateTime.make(new Date('1988-02-25').toISOString()),
-				end: HDateTime.make(new Date('1988-02-26').toISOString()),
+				start: HDateTime.make('2024-02-14T00:00:00.000Z'),
+				end: HDateTime.make('2024-02-15T00:00:00.000Z'),
 				val: false,
-			})
-		),
-	})
-}
-
-const mockNextScheduleEvent = (): HDict => {
-	return new HDict({
-		events: HList.make(
-			HDict.make({
-				start: HDateTime.make(new Date('1988-02-23').toISOString()),
-				end: HDateTime.make(new Date('1988-02-24').toISOString()),
-				val: true,
 			})
 		),
 	})

--- a/spec/client/schedules/ScheduleService.spec.ts
+++ b/spec/client/schedules/ScheduleService.spec.ts
@@ -5,6 +5,7 @@
 import {
 	HAYSON_MIME_TYPE,
 	HDate,
+	HDateTime,
 	HDict,
 	HGrid,
 	HList,
@@ -100,6 +101,35 @@ const mockCalendar = (): HDict => {
 				dayOfWeek: 2,
 			}),
 		]),
+	})
+}
+
+const mockScheduleEvents = (): HDict => {
+	return new HDict({
+		events: HList.make(
+			HDict.make({
+				start: HDateTime.make(new Date('1988-02-23').toISOString()),
+				end: HDateTime.make(new Date('1988-02-24').toISOString()),
+				val: true,
+			}),
+			HDict.make({
+				start: HDateTime.make(new Date('1988-02-25').toISOString()),
+				end: HDateTime.make(new Date('1988-02-26').toISOString()),
+				val: false,
+			})
+		),
+	})
+}
+
+const mockNextScheduleEvent = (): HDict => {
+	return new HDict({
+		events: HList.make(
+			HDict.make({
+				start: HDateTime.make(new Date('1988-02-23').toISOString()),
+				end: HDateTime.make(new Date('1988-02-24').toISOString()),
+				val: true,
+			})
+		),
 	})
 }
 
@@ -741,6 +771,49 @@ describe('ScheduleService', () => {
 			await service.readCalendarSchedulesById(HRef.make('c123'))
 			expect(fetchMock.lastUrl()).toEqual(
 				`${getUrl(ScheduleServiceEndpoints.Calendars)}/c123/schedules`
+			)
+		})
+	})
+
+	describe('#readScheduleEvents', () => {
+		beforeEach(() => {
+			resp = mockScheduleEvents()
+			prepareMock(
+				'GET',
+				`${ScheduleServiceEndpoints.Schedules}/123`,
+				resp
+			)
+		})
+
+		it('return events for schedule within range', async () => {
+			const start = '2024-02-12T00:00:00.000Z'
+			const end = '2024-02-13T00:00:00.000Z'
+
+			await service.readScheduleEvents(HRef.make('123'), {
+				start,
+				end,
+			})
+
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/events?start=${encodeURIComponent(
+					start
+				)}&end=${encodeURIComponent(end)}`
+			)
+		})
+
+		it('return next event for schedule from start date', async () => {
+			const start = '2024-02-12T00:00:00.000Z'
+
+			await service.readScheduleEvents(HRef.make('123'), {
+				start,
+			})
+
+			expect(fetchMock.lastUrl()).toEqual(
+				`${getUrl(
+					ScheduleServiceEndpoints.Schedules
+				)}/123/events?start=${encodeURIComponent(start)}`
 			)
 		})
 	})

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -5,7 +5,6 @@
 import { HDict, HGrid, HRef } from 'haystack-core'
 import {
 	ScheduleEventsReadOptions,
-	ScheduleEventsResponse,
 	SchedulePointUpdate,
 	ScheduleReadOptions,
 	ScheduleServiceEndpoints,

--- a/src/client/schedules/ScheduleService.ts
+++ b/src/client/schedules/ScheduleService.ts
@@ -4,6 +4,8 @@
 
 import { HDict, HGrid, HRef } from 'haystack-core'
 import {
+	ScheduleEventsReadOptions,
+	ScheduleEventsResponse,
 	SchedulePointUpdate,
 	ScheduleReadOptions,
 	ScheduleServiceEndpoints,
@@ -315,6 +317,30 @@ export class ScheduleService {
 	): Promise<HGrid<Schedule>> {
 		return fetchVal<HGrid<Schedule>>(
 			`${this.#calendarsUrl}/${HRef.make(id).value}/schedules`,
+			{
+				...this.#serviceConfig.getDefaultOptions(),
+			}
+		)
+	}
+
+	/**
+	 * Reads the events associated with a schedule.
+	 *
+	 * Returns the events within the start -> end range,
+	 * or, if no end provided, will return the next scheduled event.
+	 *
+	 * @param id The record id.
+	 * @param options The range to use for event lookup.
+	 * @returns The events for the Schedule.
+	 */
+	async readScheduleEvents<ScheduleEventsResponse extends HDict>(
+		id: string | HRef,
+		options: ScheduleEventsReadOptions
+	): Promise<ScheduleEventsResponse> {
+		return fetchVal<ScheduleEventsResponse>(
+			`${this.#schedulesUrl}/${HRef.make(id).value}/events${encodeQuery({
+				...(options ?? {}),
+			})}`,
 			{
 				...this.#serviceConfig.getDefaultOptions(),
 			}

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -50,12 +50,18 @@ export type ScheduleEventsReadOptions = {
 	end?: string
 }
 
+/**
+ * The shape of an event on a Schedule.
+ */
 interface ScheduleEvent extends HDict {
 	startDate: HDateTime
 	endDate: HDateTime
 	val: OptionalHVal
 }
 
+/**
+ * The response from the Schedule Events endpoint.
+ */
 export interface ScheduleEventsResponse extends HDict {
 	events: HList<ScheduleEvent>
 }

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -53,7 +53,7 @@ export type ScheduleEventsReadOptions = {
 /**
  * The shape of an event on a Schedule.
  */
-interface ScheduleEvent extends HDict {
+export interface ScheduleEvent extends HDict {
 	startTime: HDateTime
 	endTime: HDateTime
 	val: OptionalHVal

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -54,8 +54,8 @@ export type ScheduleEventsReadOptions = {
  * The shape of an event on a Schedule.
  */
 interface ScheduleEvent extends HDict {
-	startDate: HDateTime
-	endDate: HDateTime
+	startTime: HDateTime
+	endTime: HDateTime
 	val: OptionalHVal
 }
 

--- a/src/client/schedules/types.ts
+++ b/src/client/schedules/types.ts
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020, J2 Innovations. All Rights Reserved
+ * Copyright (c) 2020-2024, J2 Innovations. All Rights Reserved
  */
 
-import { HList, HRef } from 'haystack-core'
+import { HDateTime, HDict, HList, HRef, OptionalHVal } from 'haystack-core'
 
 /**
  * The entry endpoints for the Schedule Service
@@ -40,6 +40,24 @@ export type ScheduleReadOptions = {
 	 * Omit the specified columns from the response.
 	 */
 	omit?: string[]
+}
+
+/**
+ * Options for reading a Schedules events.
+ */
+export type ScheduleEventsReadOptions = {
+	start: string
+	end?: string
+}
+
+interface ScheduleEvent extends HDict {
+	startDate: HDateTime
+	endDate: HDateTime
+	val: OptionalHVal
+}
+
+export interface ScheduleEventsResponse extends HDict {
+	events: HList<ScheduleEvent>
 }
 
 /**


### PR DESCRIPTION
This PR adds the following functionality:
- Adds the endpoint for retrieving a schedules events.
- Adds the interfaces pertaining to the new endpoint.
- Updates the unit tests to ensure correct endpoint URL called.