### PR TITLE
FT-6091: Some Historian Builder icons not displaying correctly.

### DIFF
--- a/src/client/fetchVal.ts
+++ b/src/client/fetchVal.ts
@@ -77,6 +77,21 @@ function validateValue<Value extends HVal>(
 	return val as Value
 }
 
+function extendRecord(
+	recordCollection: HVal | undefined | null
+): HVal | undefined | null {
+	const isAnEquip = (recordCollection as HGrid)
+		.getColumns()
+		.some((record) => record.name === 'equip')
+	const rows = (recordCollection as HGrid).getRows()
+	if (isAnEquip && rows.length > 0) {
+		rows.forEach((recordRow) => {
+			recordRow.set('icon', 'EquipIcon')
+		})
+	}
+	return recordCollection
+}
+
 async function parseResponse(resp: Response): Promise<HVal | undefined | null> {
 	const contentType = resp.headers.get(CONTENT_TYPE_HEADER)
 
@@ -96,7 +111,7 @@ async function parseResponse(resp: Response): Promise<HVal | undefined | null> {
  * @returns The read grid.
  */
 async function readVal<Value extends HVal>(resp: Response): Promise<Value> {
-	const val = (await parseResponse(resp)) as Value
+	const val = extendRecord(await parseResponse(resp)) as Value
 	return validateValue<Value>(val as Value | null | undefined, resp)
 }
 


### PR DESCRIPTION
# MR details

These changes introduce logic to display the correct icon coming from the record setting the icon-attribute when this is equip and doesn't have it.

**Problem that resolves**

Happens when access to Create Chart intoHistorian 2.0 Builder APP the nodes for equip items are not displaying any icon; showing the default unknown element **BorderOutlined**.

**How the fix works**

* When the data got fetch using **fetchVal** and process it using **readVal** at **client/fetchVal**.
* Inside of the **readVal** method the data got parsed make it readable and transform to HVal record value.
* At end of the parsed data is getting use the new method **extendRecord** to analyse if the Grid-collection contains the the attribute **equip** and if this have it each Grid's row is going to get set the attribute "icon" with the default value for it "EquipIcon".

**Logic Diagram**

<img width="614" height="379" alt="Screenshot 2025-12-18 at 10 46 28 a m" src="https://github.com/user-attachments/assets/e5f3981e-9e8f-48af-97d2-4f953b640167" />

**Screenshot changes**

Before:
<img width="384" height="321" alt="Screenshot 2025-12-18 at 10 46 44 a m" src="https://github.com/user-attachments/assets/fd32ed0f-efdf-47e4-b53d-d5f882679182" />

After:
<img width="449" height="542" alt="Screenshot 2025-12-18 at 10 46 55 a m" src="https://github.com/user-attachments/assets/b5a60a24-6ad3-4992-9123-a30e689c0a7e" />
