### PR TITLE
fix (invokeAction): send empty rows array for parameterless actions

### DIFF
--- a/spec/client/OpsService.spec.ts
+++ b/spec/client/OpsService.spec.ts
@@ -408,6 +408,24 @@ describe('OpsService', function (): void {
 				fetchMock.lastCall(getOpUrl('invokeAction'))?.[1]?.body
 			).toBe(argsZinc)
 		})
+
+		it('encodes an empty rows array when no arguments are passed', async function (): Promise<void> {
+			preparePostOp('invokeAction')
+
+			await ops.invokeAction('123', 'foo')
+
+			const emptyArgsZinc = HGrid.make({
+				meta: HDict.make({
+					id: HRef.make('123'),
+					action: HStr.make('foo'),
+				}),
+				rows: [],
+			}).toZinc()
+
+			expect(
+				fetchMock.lastCall(getOpUrl('invokeAction'))?.[1]?.body
+			).toBe(emptyArgsZinc)
+		})
 	}) // #invokeAction()
 
 	describe('#nav()', function (): void {

--- a/src/client/OpsService.ts
+++ b/src/client/OpsService.ts
@@ -339,7 +339,7 @@ export class OpsService {
 					id: HRef.make(id),
 					action: HStr.make(action),
 				}),
-				rows: [args ? (makeValue(args) as HDict) : HDict.make()],
+				rows: args ? [makeValue(args) as HDict] : [],
 			})
 		)
 	}


### PR DESCRIPTION
Fixes a Zinc serialization error when invoking a parameterless action.

Root cause: OpsService.invokeAction() was including an empty row (rows: [HDict.make()]) in the request grid when no arguments were provided. This produced malformed Zinc with no column definitions but one empty row, causing FIN's server to reject the request with ParseErr: No columns defined [line 3].

Fix: Changed rows to an empty array when args is undefined, producing valid Zinc with the empty keyword instead.

Changes:
- src/client/OpsService.ts - changed invokeAction rows from [args ? makeValue(args) : HDict.make()] to args ? [makeValue(args)] : []
- spec/client/OpsService.spec.ts - added unit test verifying the no-args request body produces an empty rows grid

Example of invoking a parameterless action screenshots:
<img width="1120" height="368" alt="Screenshot 2026-07-22 at 9 10 44 PM" src="https://github.com/user-attachments/assets/9de9e6fa-939c-416c-97c4-1f713c24612b" />

<img width="1114" height="259" alt="Screenshot 2026-07-22 at 9 10 52 PM" src="https://github.com/user-attachments/assets/d124d568-e4a2-49e8-a92c-3d52412fde6c" />

<img width="1115" height="348" alt="Screenshot 2026-07-22 at 9 11 00 PM" src="https://github.com/user-attachments/assets/c71b9c2b-ae01-41c8-9f90-b3b8f60d9395" />
